### PR TITLE
Add basic chat interface with user auth and OpenAI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Chat Encuesta
+
+Este proyecto contiene un ejemplo sencillo de chat en PHP que utiliza la API de OpenAI y MySQL. Incluye scripts de registro, inicio de sesión y una interfaz de chat donde el usuario puede seleccionar tema claro u oscuro y un color de acento.
+
+## Archivos principales
+- `db.php`: conexión PDO a la base de datos `marhar345_merlin`.
+- `schema.sql`: script para crear la estructura de tablas.
+- `register.php` / `login.php` / `logout.php`: autenticación básica.
+- `chat.php`: interfaz conversacional que almacena cada mensaje y consulta la API de OpenAI.
+- `openai.php`: función helper para comunicarse con la API.
+
+Antes de usar la aplicación, importa `schema.sql` en tu base de datos (por ejemplo, con phpMyAdmin) y configura las credenciales en `db.php`.
+
+Para que la API funcione necesitas definir la variable de entorno `OPENAI_API_KEY` con tu clave privada.

--- a/chat.php
+++ b/chat.php
@@ -1,0 +1,116 @@
+<?php
+session_start();
+require 'db.php';
+require 'openai.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$usuario_id = $_SESSION['usuario_id'];
+
+// Obtener preferencias de diseño o crear valores por defecto
+$stmt = $pdo->prepare("SELECT tema, color_preferido FROM preferencias_disenio WHERE usuario_id = ? LIMIT 1");
+$stmt->execute([$usuario_id]);
+$pref = $stmt->fetch();
+if (!$pref) {
+    $pref = ['tema' => 'light', 'color_preferido' => '#4CAF50'];
+    $stmt = $pdo->prepare("INSERT INTO preferencias_disenio (usuario_id, tema, color_preferido) VALUES (?, ?, ?)");
+    $stmt->execute([$usuario_id, $pref['tema'], $pref['color_preferido']]);
+}
+
+// Actualizar preferencias si se envían por formulario
+if (isset($_POST['tema']) && isset($_POST['color'])) {
+    $pref['tema'] = $_POST['tema'];
+    $pref['color_preferido'] = $_POST['color'];
+    $stmt = $pdo->prepare("UPDATE preferencias_disenio SET tema = ?, color_preferido = ? WHERE usuario_id = ?");
+    $stmt->execute([$pref['tema'], $pref['color_preferido'], $usuario_id]);
+}
+
+// Buscar o crear conversación
+$stmt = $pdo->prepare("SELECT id FROM conversaciones WHERE usuario_id = ? LIMIT 1");
+$stmt->execute([$usuario_id]);
+$conver = $stmt->fetch();
+if (!$conver) {
+    $stmt = $pdo->prepare("INSERT INTO conversaciones (usuario_id) VALUES (?)");
+    $stmt->execute([$usuario_id]);
+    $conver_id = $pdo->lastInsertId();
+} else {
+    $conver_id = $conver['id'];
+}
+
+// Enviar mensaje
+if (isset($_POST['mensaje']) && trim($_POST['mensaje']) !== '') {
+    $mensaje = trim($_POST['mensaje']);
+    $stmt = $pdo->prepare("INSERT INTO mensajes (conversacion_id, emisor, texto) VALUES (?, 'usuario', ?)");
+    $stmt->execute([$conver_id, $mensaje]);
+
+    // Construir historial para la API
+    $stmt = $pdo->prepare("SELECT emisor, texto FROM mensajes WHERE conversacion_id = ? ORDER BY id");
+    $stmt->execute([$conver_id]);
+    $historial = $stmt->fetchAll();
+    $messages = [];
+    foreach ($historial as $m) {
+        $messages[] = ['role' => $m['emisor'] === 'usuario' ? 'user' : 'assistant', 'content' => $m['texto']];
+    }
+
+    // Prompt inicial si es el primer mensaje
+    if (count($messages) === 1) {
+        $messages = array_merge([
+            ['role' => 'system', 'content' => 'Eres un asistente que realiza una encuesta de forma amena para comprender el negocio del usuario. Informa que las respuestas se guardarán y se utiliza la API de OpenAI.']
+        ], $messages);
+    }
+
+    $respuesta = call_openai_api($messages);
+
+    $stmt = $pdo->prepare("INSERT INTO mensajes (conversacion_id, emisor, texto) VALUES (?, 'asistente', ?)");
+    $stmt->execute([$conver_id, $respuesta]);
+}
+
+// Obtener mensajes para mostrar
+$stmt = $pdo->prepare("SELECT emisor, texto, fecha_envio FROM mensajes WHERE conversacion_id = ? ORDER BY id");
+$stmt->execute([$conver_id]);
+$mensajes = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="es" class="<?php echo htmlspecialchars($pref['tema']); ?>">
+<head>
+<meta charset="UTF-8">
+<title>Chat</title>
+<style>
+body.light { background: #fff; color: #000; }
+body.dark { background: #121212; color: #eee; }
+.user { text-align: right; }
+.message { margin: 5px 0; padding: 8px; border-radius: 4px; max-width: 70%; }
+.user .message { background: <?php echo htmlspecialchars($pref['color_preferido']); ?>; color: #fff; margin-left: auto; }
+.assistant .message { background: #ccc; color: #000; }
+</style>
+</head>
+<body class="<?php echo htmlspecialchars($pref['tema']); ?>">
+<h1>Chat</h1>
+<form method="post" style="margin-bottom:1em;">
+    Tema:
+    <select name="tema">
+        <option value="light" <?php if($pref['tema']==='light') echo 'selected'; ?>>Claro</option>
+        <option value="dark" <?php if($pref['tema']==='dark') echo 'selected'; ?>>Oscuro</option>
+    </select>
+    Color: <input type="color" name="color" value="<?php echo htmlspecialchars($pref['color_preferido']); ?>">
+    <button type="submit">Guardar</button>
+</form>
+<div id="chat">
+<?php foreach ($mensajes as $m): ?>
+    <div class="<?php echo $m['emisor']; ?>">
+        <div class="message">
+            <?php echo nl2br(htmlspecialchars($m['texto'])); ?>
+        </div>
+    </div>
+<?php endforeach; ?>
+</div>
+<form method="post">
+    <input name="mensaje" placeholder="Escribe un mensaje" style="width:80%;">
+    <button type="submit">Enviar</button>
+</form>
+<p><a href="logout.php">Cerrar sesión</a></p>
+</body>
+</html>

--- a/db.php
+++ b/db.php
@@ -1,0 +1,23 @@
+<?php
+// db.php - Database connection using PDO
+
+$host = 'localhost';
+$db   = 'marhar345_merlin';
+$user = 'YOUR_DB_USER';
+$pass = 'YOUR_DB_PASSWORD';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    // In production you might log this error to a file instead of showing it
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
+

--- a/login.php
+++ b/login.php
@@ -1,0 +1,37 @@
+<?php
+session_start();
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email    = trim($_POST['email']);
+    $password = $_POST['password'];
+
+    $stmt = $pdo->prepare("SELECT id, password FROM usuarios WHERE email = ? LIMIT 1");
+    $stmt->execute([$email]);
+    $usuario = $stmt->fetch();
+
+    if ($usuario && password_verify($password, $usuario['password'])) {
+        $_SESSION['usuario_id'] = $usuario['id'];
+        header('Location: chat.php');
+        exit;
+    } else {
+        $error = 'Credenciales incorrectas.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<form method="post">
+    <input name="email" type="email" placeholder="Email" required><br>
+    <input name="password" type="password" placeholder="Contraseña" required><br>
+    <button type="submit">Entrar</button>
+</form>
+<?php if (!empty($error)) echo "<p>$error</p>"; ?>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,4 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');

--- a/openai.php
+++ b/openai.php
@@ -1,0 +1,30 @@
+<?php
+// Simple helper function to query the OpenAI API using curl
+function call_openai_api(array $messages): string {
+    $apiKey = getenv('OPENAI_API_KEY');
+    if (!$apiKey) {
+        return 'Error: OPENAI_API_KEY not set';
+    }
+
+    $data = [
+        'model' => 'gpt-3.5-turbo',
+        'messages' => $messages,
+    ];
+
+    $ch = curl_init('https://api.openai.com/v1/chat/completions');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . $apiKey,
+    ]);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+        return 'Error connecting to OpenAI API';
+    }
+
+    $result = json_decode($response, true);
+    return $result['choices'][0]['message']['content'] ?? 'No response';
+}

--- a/register.php
+++ b/register.php
@@ -1,0 +1,44 @@
+<?php
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $nombre   = trim($_POST['nombre']);
+    $apellido = trim($_POST['apellido']);
+    $empresa  = trim($_POST['empresa']);
+    $email    = trim($_POST['email']);
+    $telefono = trim($_POST['telefono']);
+    $password = $_POST['password'];
+
+    $stmt = $pdo->prepare("SELECT id FROM usuarios WHERE email = ? OR telefono = ? LIMIT 1");
+    $stmt->execute([$email, $telefono]);
+    if ($stmt->fetch()) {
+        $error = 'Ya existe un usuario con ese email o teléfono.';
+    } else {
+        $hash = password_hash($password, PASSWORD_BCRYPT);
+        $stmt = $pdo->prepare("INSERT INTO usuarios (nombre, apellido, empresa, email, telefono, password) VALUES (?, ?, ?, ?, ?, ?)");
+        $stmt->execute([$nombre, $apellido, $empresa, $email, $telefono, $hash]);
+        header('Location: login.php');
+        exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Registro</title>
+</head>
+<body>
+<h1>Registro</h1>
+<form method="post">
+    <input name="nombre" placeholder="Nombre" required><br>
+    <input name="apellido" placeholder="Apellido" required><br>
+    <input name="empresa" placeholder="Empresa"><br>
+    <input name="email" type="email" placeholder="Email" required><br>
+    <input name="telefono" placeholder="Teléfono" required><br>
+    <input name="password" type="password" placeholder="Contraseña" required><br>
+    <button type="submit">Registrar</button>
+</form>
+<?php if (!empty($error)) echo "<p>$error</p>"; ?>
+</body>
+</html>

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,72 @@
+-- Database schema for the chat application
+-- Ensure you are using the marhar345_merlin database
+
+USE marhar345_merlin;
+
+-- Table of users
+CREATE TABLE IF NOT EXISTS usuarios (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre       VARCHAR(100) NOT NULL,
+    apellido     VARCHAR(100) NOT NULL,
+    empresa      VARCHAR(255),
+    email        VARCHAR(255) NOT NULL UNIQUE,
+    telefono     VARCHAR(50) UNIQUE,
+    password     VARCHAR(255) NOT NULL,
+    foto         VARCHAR(255),
+    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Design preferences
+CREATE TABLE IF NOT EXISTS preferencias_disenio (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    tema ENUM('light','dark') DEFAULT 'light',
+    color_preferido VARCHAR(50),
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+-- Conversations
+CREATE TABLE IF NOT EXISTS conversaciones (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    fecha_inicio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+-- Messages
+CREATE TABLE IF NOT EXISTS mensajes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    conversacion_id INT NOT NULL,
+    emisor ENUM('usuario','asistente') NOT NULL,
+    texto TEXT NOT NULL,
+    fecha_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (conversacion_id) REFERENCES conversaciones(id) ON DELETE CASCADE
+);
+
+-- Admin defined questions
+CREATE TABLE IF NOT EXISTS preguntas_admin (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    texto_pregunta TEXT NOT NULL,
+    orden INT DEFAULT 0
+);
+
+-- User answers to admin questions
+CREATE TABLE IF NOT EXISTS respuestas (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    pregunta_id INT NOT NULL,
+    respuesta TEXT,
+    fecha_respuesta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
+    FOREIGN KEY (pregunta_id) REFERENCES preguntas_admin(id) ON DELETE CASCADE
+);
+
+-- Optional analysis results
+CREATE TABLE IF NOT EXISTS resultados_analisis (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    analisis TEXT,
+    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- add SQL schema for all chat tables
- add registration and login forms with validation
- add simple OpenAI client helper
- add chat page with theme preferences stored in DB and conversation history
- include logout script and minimal README

## Testing
- `php -l register.php`
- `php -l login.php`
- `php -l logout.php`
- `php -l openai.php`
- `php -l chat.php`
- `php -l db.php`


------
https://chatgpt.com/codex/tasks/task_e_688a25cab4d883258c90449ca429a6f7