### PR TITLE
Add dynamic theme updates in chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Chat Encuesta
+
+Este proyecto contiene un ejemplo sencillo de chat en PHP que utiliza la API de OpenAI y MySQL. Incluye scripts de registro, inicio de sesión y una interfaz de chat donde el usuario puede seleccionar tema claro u oscuro y un color de acento. Ahora el tema y el color pueden cambiar dinámicamente a medida que el usuario responde en el chat.
+
+## Archivos principales
+- `db.php`: conexión PDO a la base de datos `marhar345_merlin`.
+- `schema.sql`: script para crear la estructura de tablas.
+- `register.php` / `login.php` / `logout.php`: autenticación básica.
+- `admin.php`: panel protegido para gestionar usuarios y preguntas.
+- `chat.php`: interfaz conversacional que almacena cada mensaje y consulta la API de OpenAI.
+- `openai.php`: función helper para comunicarse con la API.
+
+Antes de usar la aplicación, importa `schema.sql` en tu base de datos (por ejemplo, con phpMyAdmin) y configura las credenciales en `db.php`.
+
+Para que la API funcione necesitas definir la variable de entorno `OPENAI_API_KEY` con tu clave privada.
+
+## Preguntas iniciales y prompts
+`prompts.php` contiene las instrucciones y preguntas base que se envían a la API cuando un usuario inicia la conversación. Puedes ejecutar `php prompts.php` para mostrarlas por consola.
+`init_prompts.php` carga esas preguntas en la tabla `preguntas_admin` si quieres mantener un registro en la base de datos.
+
+Ejecuta `php init_prompts.php` una vez para pre-cargar las preguntas.
+
+Para acceder al panel de administración (`admin.php`) crea un usuario con la
+columna `es_admin` establecida en `1` dentro de la tabla `usuarios`.
+
+## Privacidad y gestión de datos
+
+Todos los mensajes intercambiados en el chat se guardan en la base de datos y se
+envían a la API de OpenAI para generar las respuestas. La información de perfil
+de los usuarios también se almacena con el fin de mantener la conversación y el
+historial.
+
+Cada usuario puede actualizar o eliminar sus datos personales desde la página
+`profile.php` una vez iniciada la sesión. Si se elimina la cuenta, se borran su
+perfil, preferencias y conversaciones asociadas.

--- a/admin.php
+++ b/admin.php
@@ -1,0 +1,84 @@
+<?php
+session_start();
+require 'db.php';
+
+if (!isset($_SESSION['usuario_id']) || empty($_SESSION['es_admin'])) {
+    header('Location: login.php');
+    exit;
+}
+
+// Handle user deletion
+if (isset($_GET['delete_user'])) {
+    $stmt = $pdo->prepare('DELETE FROM usuarios WHERE id = ?');
+    $stmt->execute([$_GET['delete_user']]);
+}
+
+// Handle question add/update/delete
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['new_question'])) {
+        $stmt = $pdo->prepare('INSERT INTO preguntas_admin (texto_pregunta) VALUES (?)');
+        $stmt->execute([$_POST['new_question']]);
+    }
+    if (isset($_POST['edit_id']) && isset($_POST['edit_text'])) {
+        $stmt = $pdo->prepare('UPDATE preguntas_admin SET texto_pregunta = ? WHERE id = ?');
+        $stmt->execute([$_POST['edit_text'], $_POST['edit_id']]);
+    }
+}
+if (isset($_GET['del_question'])) {
+    $stmt = $pdo->prepare('DELETE FROM preguntas_admin WHERE id = ?');
+    $stmt->execute([$_GET['del_question']]);
+}
+
+$users = $pdo->query('SELECT id, nombre, apellido, email, telefono, es_admin FROM usuarios')->fetchAll();
+$questions = $pdo->query('SELECT id, texto_pregunta FROM preguntas_admin ORDER BY id')->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Admin</title>
+<style>
+table {border-collapse: collapse; width:100%;}
+th,td{border:1px solid #ccc; padding:4px;}
+</style>
+</head>
+<body>
+<h1>Panel de Administración</h1>
+<p><a href="logout.php">Cerrar sesión</a></p>
+<h2>Usuarios</h2>
+<table>
+<tr><th>ID</th><th>Nombre</th><th>Email</th><th>Teléfono</th><th>Admin</th><th>Acciones</th></tr>
+<?php foreach ($users as $u): ?>
+<tr>
+<td><?php echo $u['id']; ?></td>
+<td><?php echo htmlspecialchars($u['nombre'].' '.$u['apellido']); ?></td>
+<td><?php echo htmlspecialchars($u['email']); ?></td>
+<td><?php echo htmlspecialchars($u['telefono']); ?></td>
+<td><?php echo $u['es_admin'] ? 'Sí' : 'No'; ?></td>
+<td><a href="?delete_user=<?php echo $u['id']; ?>" onclick="return confirm('Eliminar usuario?')">Eliminar</a></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<h2>Preguntas</h2>
+<table>
+<tr><th>ID</th><th>Pregunta</th><th>Acciones</th></tr>
+<?php foreach ($questions as $q): ?>
+<tr>
+<form method="post">
+<td><?php echo $q['id']; ?><input type="hidden" name="edit_id" value="<?php echo $q['id']; ?>"></td>
+<td><input type="text" name="edit_text" value="<?php echo htmlspecialchars($q['texto_pregunta']); ?>" style="width:80%"></td>
+<td>
+<button type="submit">Guardar</button>
+<a href="?del_question=<?php echo $q['id']; ?>" onclick="return confirm('Eliminar pregunta?')">Eliminar</a>
+</td>
+</form>
+</tr>
+<?php endforeach; ?>
+</table>
+<h3>Nueva pregunta</h3>
+<form method="post">
+<input type="text" name="new_question" style="width:60%">
+<button type="submit">Agregar</button>
+</form>
+</body>
+</html>

--- a/chat.php
+++ b/chat.php
@@ -1,0 +1,733 @@
+<?php
+session_start();
+require 'db.php';
+require 'openai.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$usuario_id = $_SESSION['usuario_id'];
+
+// Obtener preferencias de diseño o crear valores por defecto
+$stmt = $pdo->prepare("SELECT tema, color_preferido FROM preferencias_disenio WHERE usuario_id = ? LIMIT 1");
+$stmt->execute([$usuario_id]);
+$pref = $stmt->fetch();
+if (!$pref) {
+    $pref = ['tema' => 'dark', 'color_preferido' => '#D4AF37'];
+    $stmt = $pdo->prepare("INSERT INTO preferencias_disenio (usuario_id, tema, color_preferido) VALUES (?, ?, ?)");
+    $stmt->execute([$usuario_id, $pref['tema'], $pref['color_preferido']]);
+}
+
+// Actualizar preferencias si se envían por formulario
+if (isset($_POST['tema']) && isset($_POST['color'])) {
+    $pref['tema'] = $_POST['tema'];
+    $pref['color_preferido'] = $_POST['color'];
+    $stmt = $pdo->prepare("UPDATE preferencias_disenio SET tema = ?, color_preferido = ? WHERE usuario_id = ?");
+    $stmt->execute([$pref['tema'], $pref['color_preferido'], $usuario_id]);
+}
+
+// Buscar o crear conversación
+$stmt = $pdo->prepare("SELECT id FROM conversaciones WHERE usuario_id = ? LIMIT 1");
+$stmt->execute([$usuario_id]);
+$conver = $stmt->fetch();
+if (!$conver) {
+    $stmt = $pdo->prepare("INSERT INTO conversaciones (usuario_id) VALUES (?)");
+    $stmt->execute([$usuario_id]);
+    $conver_id = $pdo->lastInsertId();
+} else {
+    $conver_id = $conver['id'];
+}
+
+// Borrar mensaje si el usuario lo solicita
+if (isset($_GET['del_msg'])) {
+    $delId = (int)$_GET['del_msg'];
+    $stmt = $pdo->prepare('SELECT m.id FROM mensajes m JOIN conversaciones c ON m.conversacion_id = c.id WHERE m.id = ? AND c.usuario_id = ? LIMIT 1');
+    $stmt->execute([$delId, $usuario_id]);
+    if ($stmt->fetch()) {
+        $del = $pdo->prepare('DELETE FROM mensajes WHERE id = ?');
+        $del->execute([$delId]);
+    }
+    header('Location: chat.php');
+    exit;
+}
+
+// Enviar mensaje
+if (isset($_POST['mensaje']) && trim($_POST['mensaje']) !== '') {
+    $mensaje = trim($_POST['mensaje']);
+    $stmt = $pdo->prepare("INSERT INTO mensajes (conversacion_id, emisor, texto) VALUES (?, 'usuario', ?)");
+    $stmt->execute([$conver_id, $mensaje]);
+
+    // Detectar preferencias de color o tema en el mensaje
+    $mensajeLower = strtolower($mensaje);
+    $colorMap = [
+        'rojo' => '#ff0000',
+        'red' => '#ff0000',
+        'verde' => '#008000',
+        'green' => '#008000',
+        'azul' => '#0000ff',
+        'blue' => '#0000ff',
+        'amarillo' => '#ffff00',
+        'yellow' => '#ffff00',
+        'naranja' => '#ffa500',
+        'orange' => '#ffa500',
+        'violeta' => '#800080',
+        'morado' => '#800080',
+        'purple' => '#800080',
+        'negro' => '#000000',
+        'black' => '#000000',
+        'blanco' => '#ffffff',
+        'white' => '#ffffff',
+        'gris' => '#808080',
+        'gray' => '#808080',
+        'grey' => '#808080',
+        'rosa' => '#ff69b4',
+        'pink' => '#ff69b4',
+        'dorado' => '#D4AF37',
+        'gold' => '#D4AF37'
+    ];
+    $newColor = null;
+    if (preg_match('/#([0-9a-f]{3,6})/i', $mensajeLower, $m)) {
+        $newColor = '#' . $m[1];
+    } elseif (isset($colorMap[$mensajeLower])) {
+        $newColor = $colorMap[$mensajeLower];
+    }
+    if ($newColor) {
+        $pref['color_preferido'] = $newColor;
+        $stmt = $pdo->prepare('UPDATE preferencias_disenio SET color_preferido = ? WHERE usuario_id = ?');
+        $stmt->execute([$newColor, $usuario_id]);
+    }
+    if (strpos($mensajeLower, 'oscuro') !== false || strpos($mensajeLower, 'dark') !== false) {
+        $pref['tema'] = 'dark';
+        $stmt = $pdo->prepare('UPDATE preferencias_disenio SET tema = ? WHERE usuario_id = ?');
+        $stmt->execute(['dark', $usuario_id]);
+    }
+    if (strpos($mensajeLower, 'claro') !== false || strpos($mensajeLower, 'light') !== false) {
+        $pref['tema'] = 'light';
+        $stmt = $pdo->prepare('UPDATE preferencias_disenio SET tema = ? WHERE usuario_id = ?');
+        $stmt->execute(['light', $usuario_id]);
+    }
+
+    // Construir historial para la API
+    $stmt = $pdo->prepare("SELECT emisor, texto FROM mensajes WHERE conversacion_id = ? ORDER BY id");
+    $stmt->execute([$conver_id]);
+    $historial = $stmt->fetchAll();
+    $messages = [];
+    foreach ($historial as $m) {
+        $messages[] = ['role' => $m['emisor'] === 'usuario' ? 'user' : 'assistant', 'content' => $m['texto']];
+    }
+
+    // Prompt inicial y preguntas base si es el primer mensaje
+    if (count($messages) === 1) {
+        $basePrompts = include 'prompts.php';
+        $messages = array_merge($basePrompts, $messages);
+    }
+
+    $respuesta = call_openai_api($messages);
+
+    $stmt = $pdo->prepare("INSERT INTO mensajes (conversacion_id, emisor, texto) VALUES (?, 'asistente', ?)");
+    $stmt->execute([$conver_id, $respuesta]);
+}
+
+// Obtener mensajes para mostrar
+$stmt = $pdo->prepare("SELECT id, emisor, texto, fecha_envio FROM mensajes WHERE conversacion_id = ? ORDER BY id");
+$stmt->execute([$conver_id]);
+$mensajes = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="es" class="<?php echo htmlspecialchars($pref['tema']); ?>">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>✨ Celestial Chat</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+<style>
+:root {
+    --user-color: <?php echo htmlspecialchars($pref['color_preferido']); ?>;
+    --primary-gold: var(--user-color);
+    --secondary-gold: var(--user-color);
+    --deep-blue: #0B1426;
+    --navy-blue: #1A2332;
+    --light-blue: #2C3E50;
+    --accent-blue: #34495E;
+    --text-light: #ECF0F1;
+    --text-muted: #BDC3C7;
+    --shadow-gold: rgba(212, 175, 55, 0.3);
+    --gradient-bg: linear-gradient(135deg, #0B1426 0%, var(--user-color) 100%);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: var(--gradient-bg);
+    color: var(--text-light);
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+body.light {
+    --deep-blue: #F8F9FA;
+    --navy-blue: #E9ECEF;
+    --light-blue: #DEE2E6;
+    --accent-blue: #CED4DA;
+    --text-light: #212529;
+    --text-muted: #6C757D;
+    --gradient-bg: linear-gradient(135deg, #F8F9FA 0%, var(--user-color) 100%);
+}
+
+/* Header */
+.header {
+    background: rgba(11, 20, 38, 0.9);
+    backdrop-filter: blur(10px);
+    padding: 1rem 2rem;
+    border-bottom: 2px solid var(--primary-gold);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-shadow: 0 4px 20px var(--shadow-gold);
+}
+
+.header h1 {
+    color: var(--secondary-gold);
+    font-size: 1.8rem;
+    font-weight: 300;
+    letter-spacing: 2px;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.header .star-icon {
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.1); opacity: 0.8; }
+}
+
+.header-actions {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.settings-btn {
+    background: transparent;
+    border: 2px solid var(--primary-gold);
+    color: var(--primary-gold);
+    padding: 0.5rem 1rem;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 0.9rem;
+}
+
+.settings-btn:hover {
+    background: var(--primary-gold);
+    color: var(--deep-blue);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px var(--shadow-gold);
+}
+
+/* Settings Panel */
+.settings-panel {
+    background: rgba(26, 35, 50, 0.95);
+    backdrop-filter: blur(15px);
+    border: 2px solid var(--primary-gold);
+    border-radius: 15px;
+    padding: 1.5rem;
+    margin: 1rem 2rem;
+    box-shadow: 0 8px 32px var(--shadow-gold);
+    display: none;
+    animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+    from { opacity: 0; transform: translateY(-20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.settings-row {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.settings-row label {
+    color: var(--secondary-gold);
+    font-weight: 500;
+    min-width: 80px;
+}
+
+.settings-row select, .settings-row input[type="color"] {
+    background: var(--accent-blue);
+    border: 2px solid var(--primary-gold);
+    color: var(--text-light);
+    padding: 0.5rem;
+    border-radius: 8px;
+    transition: all 0.3s ease;
+}
+
+.settings-row select:focus, .settings-row input[type="color"]:focus {
+    outline: none;
+    box-shadow: 0 0 10px var(--shadow-gold);
+    transform: scale(1.05);
+}
+
+/* Chat Container */
+.chat-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 120px);
+}
+
+.chat-window {
+    flex: 1;
+    background: rgba(26, 35, 50, 0.6);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    border: 2px solid var(--primary-gold);
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    overflow-y: auto;
+    box-shadow: inset 0 4px 20px rgba(0, 0, 0, 0.3);
+    scroll-behavior: smooth;
+}
+
+.chat-window::-webkit-scrollbar {
+    width: 8px;
+}
+
+.chat-window::-webkit-scrollbar-track {
+    background: rgba(11, 20, 38, 0.5);
+    border-radius: 10px;
+}
+
+.chat-window::-webkit-scrollbar-thumb {
+    background: var(--primary-gold);
+    border-radius: 10px;
+}
+
+/* Messages */
+.message-container {
+    margin: 1rem 0;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.8rem;
+    animation: fadeInUp 0.4s ease-out;
+}
+
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.message-container.user {
+    flex-direction: row-reverse;
+}
+
+.message-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    flex-shrink: 0;
+}
+
+.message-container.user .message-avatar {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    color: var(--deep-blue);
+}
+
+.message-container.assistant .message-avatar {
+    background: linear-gradient(135deg, var(--light-blue), var(--accent-blue));
+    color: var(--secondary-gold);
+}
+
+.message-content {
+    max-width: 70%;
+    position: relative;
+}
+
+.message {
+    padding: 1rem 1.5rem;
+    border-radius: 18px;
+    position: relative;
+    line-height: 1.6;
+    word-wrap: break-word;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.message-container.user .message {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    color: var(--deep-blue);
+    border-bottom-right-radius: 5px;
+}
+
+.message-container.assistant .message {
+    background: rgba(52, 73, 94, 0.8);
+    backdrop-filter: blur(10px);
+    color: var(--text-light);
+    border: 1px solid rgba(212, 175, 55, 0.3);
+    border-bottom-left-radius: 5px;
+}
+
+.message-actions {
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.message-container:hover .message-actions {
+    opacity: 1;
+}
+
+.delete-btn {
+    background: rgba(231, 76, 60, 0.9);
+    border: none;
+    color: white;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+}
+
+.delete-btn:hover {
+    background: #E74C3C;
+    transform: scale(1.1);
+}
+
+.message-time {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 0.3rem;
+    opacity: 0.7;
+}
+
+/* Input Area */
+.input-area {
+    background: rgba(26, 35, 50, 0.9);
+    backdrop-filter: blur(15px);
+    border-radius: 25px;
+    border: 2px solid var(--primary-gold);
+    padding: 1rem;
+    box-shadow: 0 -4px 20px var(--shadow-gold);
+}
+
+.input-form {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.message-input {
+    flex: 1;
+    background: rgba(52, 73, 94, 0.5);
+    border: 2px solid rgba(212, 175, 55, 0.3);
+    color: var(--text-light);
+    padding: 1rem 1.5rem;
+    border-radius: 25px;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+    outline: none;
+}
+
+.message-input:focus {
+    border-color: var(--primary-gold);
+    box-shadow: 0 0 15px var(--shadow-gold);
+    background: rgba(52, 73, 94, 0.8);
+}
+
+.message-input::placeholder {
+    color: var(--text-muted);
+}
+
+.send-btn {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    border: none;
+    color: var(--deep-blue);
+    padding: 1rem 1.5rem;
+    border-radius: 25px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.send-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px var(--shadow-gold);
+}
+
+.send-btn:active {
+    transform: translateY(0);
+}
+
+/* Navigation */
+.navigation {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(11, 20, 38, 0.95);
+    backdrop-filter: blur(15px);
+    border-top: 2px solid var(--primary-gold);
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    z-index: 50;
+}
+
+.nav-link {
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+    border-radius: 15px;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.nav-link:hover {
+    color: var(--primary-gold);
+    background: rgba(212, 175, 55, 0.1);
+    transform: translateY(-2px);
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .header {
+        padding: 1rem;
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    .settings-panel {
+        margin: 1rem;
+    }
+    
+    .chat-container {
+        padding: 1rem;
+        height: calc(100vh - 160px);
+    }
+    
+    .message-content {
+        max-width: 85%;
+    }
+    
+    .navigation {
+        padding: 1rem;
+        gap: 1rem;
+    }
+    
+    .nav-link span {
+        display: none;
+    }
+}
+
+/* Empty State */
+.empty-state {
+    text-align: center;
+    padding: 3rem 2rem;
+    color: var(--text-muted);
+}
+
+.empty-state i {
+    font-size: 3rem;
+    color: var(--primary-gold);
+    margin-bottom: 1rem;
+}
+
+.empty-state h3 {
+    color: var(--secondary-gold);
+    margin-bottom: 0.5rem;
+}
+</style>
+</head>
+<body class="<?php echo htmlspecialchars($pref['tema']); ?>">
+
+<!-- Header -->
+<header class="header">
+    <h1>
+        <i class="fas fa-star star-icon"></i>
+        Celestial Chat
+    </h1>
+    <div class="header-actions">
+        <button class="settings-btn" onclick="toggleSettings()">
+            <i class="fas fa-cog"></i> Configuración
+        </button>
+    </div>
+</header>
+
+<!-- Settings Panel -->
+<div id="settings-panel" class="settings-panel">
+    <form method="post">
+        <div class="settings-row">
+            <label><i class="fas fa-palette"></i> Tema:</label>
+            <select name="tema">
+                <option value="dark" <?php if($pref['tema']==='dark') echo 'selected'; ?>>🌙 Oscuro</option>
+                <option value="light" <?php if($pref['tema']==='light') echo 'selected'; ?>>☀️ Claro</option>
+            </select>
+        </div>
+        <div class="settings-row">
+            <label><i class="fas fa-paint-brush"></i> Color:</label>
+            <input type="color" name="color" value="<?php echo htmlspecialchars($pref['color_preferido']); ?>">
+            <button type="submit" class="settings-btn">
+                <i class="fas fa-save"></i> Guardar
+            </button>
+        </div>
+    </form>
+</div>
+
+<!-- Chat Container -->
+<div class="chat-container">
+    <div class="chat-window" id="chat-window">
+        <?php if (empty($mensajes)): ?>
+            <div class="empty-state">
+                <i class="fas fa-comments"></i>
+                <h3>¡Bienvenido al Chat Celestial!</h3>
+                <p>Comienza una conversación escribiendo tu primer mensaje.</p>
+            </div>
+        <?php else: ?>
+            <?php foreach ($mensajes as $m): ?>
+                <div class="message-container <?php echo $m['emisor']; ?>">
+                    <div class="message-avatar">
+                        <?php if ($m['emisor'] === 'usuario'): ?>
+                            <i class="fas fa-user"></i>
+                        <?php else: ?>
+                            <i class="fas fa-robot"></i>
+                        <?php endif; ?>
+                    </div>
+                    <div class="message-content">
+                        <div class="message">
+                            <?php echo nl2br(htmlspecialchars($m['texto'])); ?>
+                            <div class="message-actions">
+                                <button class="delete-btn" onclick="deleteMessage(<?php echo $m['id']; ?>)">
+                                    <i class="fas fa-trash"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="message-time">
+                            <?php echo date('H:i', strtotime($m['fecha_envio'])); ?>
+                        </div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </div>
+    
+    <!-- Input Area -->
+    <div class="input-area">
+        <form method="post" class="input-form">
+            <input 
+                name="mensaje" 
+                class="message-input"
+                placeholder="✨ Escribe tu mensaje mágico aquí..." 
+                type="text"
+                autocomplete="off"
+                required
+            >
+            <button type="submit" class="send-btn">
+                <i class="fas fa-paper-plane"></i>
+                <span>Enviar</span>
+            </button>
+        </form>
+    </div>
+</div>
+
+<!-- Navigation -->
+<nav class="navigation">
+    <a href="profile.php" class="nav-link">
+        <i class="fas fa-user-circle"></i>
+        <span>Mi Perfil</span>
+    </a>
+    <a href="logout.php" class="nav-link">
+        <i class="fas fa-sign-out-alt"></i>
+        <span>Cerrar Sesión</span>
+    </a>
+</nav>
+
+<script>
+// Toggle Settings Panel
+function toggleSettings() {
+    const panel = document.getElementById('settings-panel');
+    panel.style.display = panel.style.display === 'none' || panel.style.display === '' ? 'block' : 'none';
+}
+
+// Delete Message
+function deleteMessage(id) {
+    if (confirm('¿Estás seguro de que quieres eliminar este mensaje?')) {
+        window.location.href = '?del_msg=' + id;
+    }
+}
+
+// Auto-scroll to bottom
+function scrollToBottom() {
+    const chatWindow = document.getElementById('chat-window');
+    chatWindow.scrollTop = chatWindow.scrollHeight;
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    const messageInput = document.querySelector('.message-input');
+    messageInput.focus();
+    scrollToBottom();
+});
+
+document.querySelector('.message-input').addEventListener('keypress', function(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        this.closest('form').submit();
+    }
+});
+
+document.addEventListener('click', function(e) {
+    const panel = document.getElementById('settings-panel');
+    const settingsBtn = document.querySelector('.settings-btn');
+    
+    if (!panel.contains(e.target) && !settingsBtn.contains(e.target)) {
+        panel.style.display = 'none';
+    }
+});
+
+let typingDots = 0;
+setInterval(() => {
+    const input = document.querySelector('.message-input');
+    if (document.activeElement === input && input.value === '') {
+        typingDots = (typingDots + 1) % 4;
+        const dots = '.'.repeat(typingDots);
+        input.placeholder = `✨ Escribe tu mensaje mágico aquí${dots}`;
+    }
+}, 500);
+</script>
+
+</body>
+</html>

--- a/db.php
+++ b/db.php
@@ -1,0 +1,23 @@
+<?php
+// db.php - Database connection using PDO
+
+$host = 'localhost';
+$db   = 'marhar345_merlin';
+$user = 'YOUR_DB_USER';
+$pass = 'YOUR_DB_PASSWORD';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    // In production you might log this error to a file instead of showing it
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
+

--- a/init_prompts.php
+++ b/init_prompts.php
@@ -1,0 +1,15 @@
+<?php
+// init_prompts.php - Load base prompts from prompts.php into the database
+require 'db.php';
+$prompts = include 'prompts.php';
+
+$stmt = $pdo->prepare('INSERT INTO preguntas_admin (texto_pregunta, orden) VALUES (?, ?)');
+$order = 1;
+foreach ($prompts as $p) {
+    if ($p['role'] === 'assistant') {
+        $stmt->execute([$p['content'], $order]);
+        $order++;
+    }
+}
+
+echo "Preguntas cargadas: " . ($order - 1) . "\n";

--- a/login.php
+++ b/login.php
@@ -1,0 +1,40 @@
+<?php
+session_start();
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email    = trim($_POST['email']);
+    $password = $_POST['password'];
+
+    $stmt = $pdo->prepare("SELECT id, password, es_admin FROM usuarios WHERE email = ? LIMIT 1");
+    $stmt->execute([$email]);
+    $usuario = $stmt->fetch();
+
+    if ($usuario && password_verify($password, $usuario['password'])) {
+        $_SESSION['usuario_id'] = $usuario['id'];
+        $_SESSION['es_admin'] = $usuario['es_admin'];
+        $destino = $usuario['es_admin'] ? 'admin.php' : 'chat.php';
+        header('Location: ' . $destino);
+        exit;
+    } else {
+        $error = 'Credenciales incorrectas.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<form method="post">
+    <input name="email" type="email" placeholder="Email" required><br>
+    <input name="password" type="password" placeholder="Contraseña" required><br>
+    <button type="submit">Entrar</button>
+</form>
+<p style="font-size:small">Al usar este chat aceptas la <a href="privacy.php">política de privacidad</a>.</p>
+<?php if (!empty($error)) echo "<p>$error</p>"; ?>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,4 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');

--- a/openai.php
+++ b/openai.php
@@ -1,0 +1,30 @@
+<?php
+// Simple helper function to query the OpenAI API using curl
+function call_openai_api(array $messages): string {
+    $apiKey = getenv('OPENAI_API_KEY');
+    if (!$apiKey) {
+        return 'Error: OPENAI_API_KEY not set';
+    }
+
+    $data = [
+        'model' => 'gpt-3.5-turbo',
+        'messages' => $messages,
+    ];
+
+    $ch = curl_init('https://api.openai.com/v1/chat/completions');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . $apiKey,
+    ]);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+        return 'Error connecting to OpenAI API';
+    }
+
+    $result = json_decode($response, true);
+    return $result['choices'][0]['message']['content'] ?? 'No response';
+}

--- a/privacy.php
+++ b/privacy.php
@@ -1,0 +1,16 @@
+<?php
+// privacy.php - simple page describing data collection
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Privacidad</title>
+</head>
+<body>
+<h1>Política de privacidad</h1>
+<p>Este chat almacena los mensajes enviados por los usuarios y las respuestas generadas con la API de OpenAI.
+Los datos de perfil se guardan para mantener el historial y personalizar la experiencia.
+Puedes actualizar o eliminar tu información en cualquier momento desde tu <a href="profile.php">perfil</a>.</p>
+</body>
+</html>

--- a/profile.php
+++ b/profile.php
@@ -1,0 +1,66 @@
+<?php
+session_start();
+require 'db.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$usuario_id = $_SESSION['usuario_id'];
+
+// Obtener datos actuales
+$stmt = $pdo->prepare('SELECT nombre, apellido, empresa, email, telefono FROM usuarios WHERE id = ?');
+$stmt->execute([$usuario_id]);
+$usuario = $stmt->fetch();
+
+if (!$usuario) {
+    echo 'Usuario no encontrado';
+    exit;
+}
+
+// Actualizar datos
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
+    $nombre = trim($_POST['nombre']);
+    $apellido = trim($_POST['apellido']);
+    $empresa = trim($_POST['empresa']);
+    $email = trim($_POST['email']);
+    $telefono = trim($_POST['telefono']);
+
+    $stmt = $pdo->prepare('UPDATE usuarios SET nombre = ?, apellido = ?, empresa = ?, email = ?, telefono = ? WHERE id = ?');
+    $stmt->execute([$nombre, $apellido, $empresa, $email, $telefono, $usuario_id]);
+    header('Location: profile.php');
+    exit;
+}
+
+// Eliminar cuenta
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
+    $stmt = $pdo->prepare('DELETE FROM usuarios WHERE id = ?');
+    $stmt->execute([$usuario_id]);
+    session_destroy();
+    header('Location: register.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Perfil</title>
+</head>
+<body>
+<h1>Mi perfil</h1>
+<form method="post">
+    <input name="nombre" value="<?php echo htmlspecialchars($usuario['nombre']); ?>" required><br>
+    <input name="apellido" value="<?php echo htmlspecialchars($usuario['apellido']); ?>" required><br>
+    <input name="empresa" value="<?php echo htmlspecialchars($usuario['empresa']); ?>"><br>
+    <input name="email" type="email" value="<?php echo htmlspecialchars($usuario['email']); ?>" required><br>
+    <input name="telefono" value="<?php echo htmlspecialchars($usuario['telefono']); ?>" required><br>
+    <button type="submit" name="update">Guardar cambios</button>
+</form>
+<form method="post" onsubmit="return confirm('¿Eliminar cuenta definitivamente?')" style="margin-top:1em;">
+    <button type="submit" name="delete">Eliminar mi cuenta</button>
+</form>
+<p><a href="chat.php">Volver al chat</a></p>
+</body>
+</html>

--- a/prompts.php
+++ b/prompts.php
@@ -1,0 +1,27 @@
+<?php
+// Base prompts and questions used to initialize the conversation with OpenAI.
+// You can edit this file to customize the starting instructions or questions.
+$prompts = [
+    [
+        'role' => 'system',
+        'content' => 'Eres un asistente que realiza una encuesta de forma amena para comprender el negocio del usuario. Informa que las respuestas se guardan y que se utiliza la API de OpenAI.'
+    ],
+    [
+        'role' => 'assistant',
+        'content' => '¡Hola! Antes de empezar, puedes indicarme tu nombre o cómo prefieres que te llame?'
+    ],
+    [
+        'role' => 'assistant',
+        'content' => '¿Cuál es el objetivo principal de tu negocio o proyecto?'
+    ],
+    [
+        'role' => 'assistant',
+        'content' => '¿Tienes alguna preferencia de estilo o colores para la imagen de tu marca?'
+    ],
+];
+
+if (php_sapi_name() === 'cli' && basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
+    print_r($prompts);
+}
+
+return $prompts;

--- a/register.php
+++ b/register.php
@@ -1,0 +1,45 @@
+<?php
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $nombre   = trim($_POST['nombre']);
+    $apellido = trim($_POST['apellido']);
+    $empresa  = trim($_POST['empresa']);
+    $email    = trim($_POST['email']);
+    $telefono = trim($_POST['telefono']);
+    $password = $_POST['password'];
+
+    $stmt = $pdo->prepare("SELECT id FROM usuarios WHERE email = ? OR telefono = ? LIMIT 1");
+    $stmt->execute([$email, $telefono]);
+    if ($stmt->fetch()) {
+        $error = 'Ya existe un usuario con ese email o teléfono.';
+    } else {
+        $hash = password_hash($password, PASSWORD_BCRYPT);
+        $stmt = $pdo->prepare("INSERT INTO usuarios (nombre, apellido, empresa, email, telefono, password, es_admin) VALUES (?, ?, ?, ?, ?, ?, 0)");
+        $stmt->execute([$nombre, $apellido, $empresa, $email, $telefono, $hash]);
+        header('Location: login.php');
+        exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Registro</title>
+</head>
+<body>
+<h1>Registro</h1>
+<form method="post">
+    <input name="nombre" placeholder="Nombre" required><br>
+    <input name="apellido" placeholder="Apellido" required><br>
+    <input name="empresa" placeholder="Empresa"><br>
+    <input name="email" type="email" placeholder="Email" required><br>
+    <input name="telefono" placeholder="Teléfono" required><br>
+    <input name="password" type="password" placeholder="Contraseña" required><br>
+    <button type="submit">Registrar</button>
+</form>
+<p style="font-size:small">Al registrarte aceptas la <a href="privacy.php">política de privacidad</a> y que tus datos sean almacenados.</p>
+<?php if (!empty($error)) echo "<p>$error</p>"; ?>
+</body>
+</html>

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,73 @@
+-- Database schema for the chat application
+-- Ensure you are using the marhar345_merlin database
+
+USE marhar345_merlin;
+
+-- Table of users
+CREATE TABLE IF NOT EXISTS usuarios (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre       VARCHAR(100) NOT NULL,
+    apellido     VARCHAR(100) NOT NULL,
+    empresa      VARCHAR(255),
+    email        VARCHAR(255) NOT NULL UNIQUE,
+    telefono     VARCHAR(50) UNIQUE,
+    password     VARCHAR(255) NOT NULL,
+    foto         VARCHAR(255),
+    es_admin     TINYINT(1) DEFAULT 0,
+    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Design preferences
+CREATE TABLE IF NOT EXISTS preferencias_disenio (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    tema ENUM('light','dark') DEFAULT 'light',
+    color_preferido VARCHAR(50),
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+-- Conversations
+CREATE TABLE IF NOT EXISTS conversaciones (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    fecha_inicio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+-- Messages
+CREATE TABLE IF NOT EXISTS mensajes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    conversacion_id INT NOT NULL,
+    emisor ENUM('usuario','asistente') NOT NULL,
+    texto TEXT NOT NULL,
+    fecha_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (conversacion_id) REFERENCES conversaciones(id) ON DELETE CASCADE
+);
+
+-- Admin defined questions
+CREATE TABLE IF NOT EXISTS preguntas_admin (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    texto_pregunta TEXT NOT NULL,
+    orden INT DEFAULT 0
+);
+
+-- User answers to admin questions
+CREATE TABLE IF NOT EXISTS respuestas (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    pregunta_id INT NOT NULL,
+    respuesta TEXT,
+    fecha_respuesta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
+    FOREIGN KEY (pregunta_id) REFERENCES preguntas_admin(id) ON DELETE CASCADE
+);
+
+-- Optional analysis results
+CREATE TABLE IF NOT EXISTS resultados_analisis (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    analisis TEXT,
+    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- revamp `chat.php` with richer UI and responsive layout
- save color and theme choices when mentioned by user in conversation
- update CSS variables so the accent color updates dynamically
- mention automatic theme changes in README

## Testing
- `php -l chat.php`
- `for f in *.php; do php -l $f; done`


------
https://chatgpt.com/codex/tasks/task_e_688a25cab4d883258c90449ca429a6f7