### PR TITLE
Add prompt set management

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Este proyecto contiene un ejemplo sencillo de chat en PHP que utiliza la API de 
 - `db.php`: conexión PDO a la base de datos `marhar345_merlin`.
 - `schema.sql`: script para crear la estructura de tablas.
 - `register.php` / `login.php` / `logout.php`: autenticación básica.
-- `admin.php`: panel protegido para gestionar usuarios, preguntas y asignar un conjunto de prompts a cada uno.
+- `admin.php`: panel protegido para gestionar usuarios, preguntas y administrar los conjuntos de prompts.
 - `chat.php`: interfaz conversacional que almacena cada mensaje y consulta la API de OpenAI.
 - `openai.php`: función helper para comunicarse con la API.
 
@@ -15,10 +15,10 @@ Antes de usar la aplicación, importa `schema.sql` en tu base de datos (por ejem
 Para que la API funcione necesitas definir la variable de entorno `OPENAI_API_KEY` con tu clave privada.
 
 ## Preguntas iniciales y prompts
-`prompts.php` define distintos conjuntos de mensajes iniciales. Ejecuta `php prompts.php` para verlos por consola.
-`init_prompts.php` carga esos conjuntos en las tablas `prompt_sets` y `prompt_lines`.
+`prompts.php` define los mensajes iniciales de ejemplo. Ejecuta `php prompts.php` para verlos por consola.
+`init_prompts.php` importa estos mensajes si las tablas `prompt_sets` y `prompt_lines` están vacías.
 
-Ejecuta `php init_prompts.php` una vez para pre-cargar los prompts y asignar el conjunto por defecto a los usuarios nuevos.
+Después de la carga inicial, los prompts pueden modificarse completamente desde `admin.php`, creando o editando conjuntos y mensajes individuales.
 
 Para acceder al panel de administración (`admin.php`) crea un usuario con la
 columna `es_admin` establecida en `1` dentro de la tabla `usuarios`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Chat Encuesta
+
+Este proyecto contiene un ejemplo sencillo de chat en PHP que utiliza la API de OpenAI y MySQL. Incluye scripts de registro, inicio de sesión y una interfaz de chat donde el usuario puede seleccionar tema claro u oscuro y un color de acento. Ahora el tema y el color pueden cambiar dinámicamente a medida que el usuario responde en el chat.
+
+## Archivos principales
+- `db.php`: conexión PDO a la base de datos `marhar345_merlin`.
+- `schema.sql`: script para crear la estructura de tablas.
+- `register.php` / `login.php` / `logout.php`: autenticación básica.
+- `admin.php`: panel protegido para gestionar usuarios, preguntas y asignar un conjunto de prompts a cada uno.
+- `chat.php`: interfaz conversacional que almacena cada mensaje y consulta la API de OpenAI.
+- `openai.php`: función helper para comunicarse con la API.
+
+Antes de usar la aplicación, importa `schema.sql` en tu base de datos (por ejemplo, con phpMyAdmin) y configura las credenciales en `db.php`.
+
+Para que la API funcione necesitas definir la variable de entorno `OPENAI_API_KEY` con tu clave privada.
+
+## Preguntas iniciales y prompts
+`prompts.php` define distintos conjuntos de mensajes iniciales. Ejecuta `php prompts.php` para verlos por consola.
+`init_prompts.php` carga esos conjuntos en las tablas `prompt_sets` y `prompt_lines`.
+
+Ejecuta `php init_prompts.php` una vez para pre-cargar los prompts y asignar el conjunto por defecto a los usuarios nuevos.
+
+Para acceder al panel de administración (`admin.php`) crea un usuario con la
+columna `es_admin` establecida en `1` dentro de la tabla `usuarios`.
+
+## Privacidad y gestión de datos
+
+Todos los mensajes intercambiados en el chat se guardan en la base de datos y se
+envían a la API de OpenAI para generar las respuestas. La información de perfil
+de los usuarios también se almacena con el fin de mantener la conversación y el
+historial.
+
+Cada usuario puede actualizar o eliminar sus datos personales desde la página
+`profile.php` una vez iniciada la sesión. Si se elimina la cuenta, se borran su
+perfil, preferencias y conversaciones asociadas.

--- a/admin.php
+++ b/admin.php
@@ -74,127 +74,1060 @@ if ($selectedSet) {
     $stmt->execute([$selectedSet]);
     $promptLines = $stmt->fetchAll();
 }
+
+// Get selected set name for display
+$selectedSetName = '';
+if ($selectedSet) {
+    $stmt = $pdo->prepare('SELECT nombre FROM prompt_sets WHERE id = ?');
+    $stmt->execute([$selectedSet]);
+    $result = $stmt->fetch();
+    $selectedSetName = $result ? $result['nombre'] : '';
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
 <meta charset="UTF-8">
-<title>Admin</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>⚡ Panel de Administración - Celestial Chat</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 <style>
-table {border-collapse: collapse; width:100%;}
-th,td{border:1px solid #ccc; padding:4px;}
+:root {
+    --primary-gold: #D4AF37;
+    --secondary-gold: #FFD700;
+    --deep-blue: #0B1426;
+    --navy-blue: #1A2332;
+    --light-blue: #2C3E50;
+    --accent-blue: #34495E;
+    --text-light: #ECF0F1;
+    --text-muted: #BDC3C7;
+    --shadow-gold: rgba(212, 175, 55, 0.3);
+    --gradient-bg: linear-gradient(135deg, #0B1426 0%, #1A2332 50%, #2C3E50 100%);
+    --success-green: #27AE60;
+    --warning-orange: #F39C12;
+    --error-red: #E74C3C;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: var(--gradient-bg);
+    color: var(--text-light);
+    min-height: 100vh;
+    line-height: 1.6;
+}
+
+/* Header */
+.admin-header {
+    background: rgba(11, 20, 38, 0.9);
+    backdrop-filter: blur(10px);
+    padding: 1.5rem 2rem;
+    border-bottom: 2px solid var(--primary-gold);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    box-shadow: 0 4px 20px var(--shadow-gold);
+}
+
+.header-content {
+    max-width: 1400px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.admin-title {
+    color: var(--secondary-gold);
+    font-size: 2rem;
+    font-weight: 300;
+    letter-spacing: 1px;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.admin-actions {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.btn {
+    background: transparent;
+    border: 2px solid var(--primary-gold);
+    color: var(--primary-gold);
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+}
+
+.btn:hover {
+    background: var(--primary-gold);
+    color: var(--deep-blue);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px var(--shadow-gold);
+}
+
+.btn-danger {
+    border-color: var(--error-red);
+    color: var(--error-red);
+}
+
+.btn-danger:hover {
+    background: var(--error-red);
+    color: white;
+}
+
+.btn-success {
+    border-color: var(--success-green);
+    color: var(--success-green);
+}
+
+.btn-success:hover {
+    background: var(--success-green);
+    color: white;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    color: var(--deep-blue);
+    border: none;
+}
+
+.btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px var(--shadow-gold);
+}
+
+/* Main Container */
+.admin-container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+/* Tabs */
+.tab-navigation {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+    border-bottom: 1px solid rgba(212, 175, 55, 0.3);
+}
+
+.tab-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    padding: 1rem 1.5rem;
+    cursor: pointer;
+    border-radius: 8px 8px 0 0;
+    transition: all 0.3s ease;
+    font-size: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.tab-btn.active {
+    background: rgba(212, 175, 55, 0.1);
+    color: var(--secondary-gold);
+    border-bottom: 2px solid var(--primary-gold);
+}
+
+.tab-btn:hover {
+    color: var(--primary-gold);
+    background: rgba(212, 175, 55, 0.05);
+}
+
+/* Content Sections */
+.tab-content {
+    display: none;
+    animation: fadeIn 0.3s ease-in;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* Cards */
+.card {
+    background: rgba(26, 35, 50, 0.8);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(212, 175, 55, 0.3);
+    border-radius: 15px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid rgba(212, 175, 55, 0.2);
+}
+
+.card-title {
+    color: var(--secondary-gold);
+    font-size: 1.3rem;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+/* Tables */
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: rgba(52, 73, 94, 0.3);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.data-table th {
+    background: rgba(212, 175, 55, 0.2);
+    color: var(--secondary-gold);
+    padding: 1rem;
+    text-align: left;
+    font-weight: 600;
+    border-bottom: 2px solid var(--primary-gold);
+}
+
+.data-table td {
+    padding: 1rem;
+    border-bottom: 1px solid rgba(212, 175, 55, 0.1);
+    vertical-align: top;
+}
+
+.data-table tr:hover {
+    background: rgba(212, 175, 55, 0.05);
+}
+
+/* Forms */
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-label {
+    display: block;
+    color: var(--secondary-gold);
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+}
+
+.form-input, .form-select, .form-textarea {
+    width: 100%;
+    background: rgba(52, 73, 94, 0.5);
+    border: 2px solid rgba(212, 175, 55, 0.3);
+    color: var(--text-light);
+    padding: 0.75rem;
+    border-radius: 8px;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+    resize: vertical;
+}
+
+.form-input:focus, .form-select:focus, .form-textarea:focus {
+    outline: none;
+    border-color: var(--primary-gold);
+    box-shadow: 0 0 10px var(--shadow-gold);
+    background: rgba(52, 73, 94, 0.8);
+}
+
+.form-inline {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.form-inline .form-input {
+    flex: 1;
+    min-width: 200px;
+}
+
+/* Stats Cards */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.stat-card {
+    background: rgba(26, 35, 50, 0.8);
+    border: 1px solid rgba(212, 175, 55, 0.3);
+    border-radius: 15px;
+    padding: 1.5rem;
+    text-align: center;
+}
+
+.stat-number {
+    font-size: 2.5rem;
+    font-weight: 300;
+    color: var(--secondary-gold);
+    margin-bottom: 0.5rem;
+}
+
+.stat-label {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+/* User Badge */
+.user-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    background: rgba(212, 175, 55, 0.1);
+    color: var(--secondary-gold);
+    padding: 0.2rem 0.5rem;
+    border-radius: 12px;
+    font-size: 0.8rem;
+}
+
+/* Role Tags */
+.role-tag {
+    padding: 0.2rem 0.6rem;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: 500;
+}
+
+.role-system {
+    background: rgba(52, 152, 219, 0.2);
+    color: #3498DB;
+}
+
+.role-assistant {
+    background: rgba(155, 89, 182, 0.2);
+    color: #9B59B6;
+}
+
+.role-user {
+    background: rgba(46, 204, 113, 0.2);
+    color: #2ECC71;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .admin-header {
+        padding: 1rem;
+    }
+    
+    .header-content {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    .admin-container {
+        padding: 1rem;
+    }
+    
+    .tab-navigation {
+        flex-wrap: wrap;
+    }
+    
+    .data-table {
+        font-size: 0.9rem;
+    }
+    
+    .data-table th, .data-table td {
+        padding: 0.5rem;
+    }
+    
+    .form-inline {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}
+
+/* Loading States */
+.loading {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+/* Notifications */
+.notification {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    padding: 1rem 1.5rem;
+    border-radius: 8px;
+    color: white;
+    font-weight: 500;
+    z-index: 1000;
+    animation: slideInRight 0.3s ease-out;
+}
+
+.notification.success {
+    background: var(--success-green);
+}
+
+.notification.error {
+    background: var(--error-red);
+}
+
+@keyframes slideInRight {
+    from { transform: translateX(100%); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+}
+
+/* Empty States */
+.empty-state {
+    text-align: center;
+    padding: 3rem 2rem;
+    color: var(--text-muted);
+}
+
+.empty-state i {
+    font-size: 3rem;
+    color: var(--primary-gold);
+    margin-bottom: 1rem;
+}
+
+.empty-state h3 {
+    color: var(--secondary-gold);
+    margin-bottom: 0.5rem;
+}
 </style>
 </head>
 <body>
-<h1>Panel de Administración</h1>
-<p><a href="logout.php">Cerrar sesión</a></p>
-<h2>Usuarios</h2>
-<table>
-<tr><th>ID</th><th>Nombre</th><th>Email</th><th>Teléfono</th><th>Admin</th><th>Prompt</th><th>Acciones</th></tr>
-<?php foreach ($users as $u): ?>
-<tr>
-<td><?php echo $u['id']; ?></td>
-<td><?php echo htmlspecialchars($u['nombre'].' '.$u['apellido']); ?></td>
-<td><?php echo htmlspecialchars($u['email']); ?></td>
-<td><?php echo htmlspecialchars($u['telefono']); ?></td>
-<td><?php echo $u['es_admin'] ? 'Sí' : 'No'; ?></td>
-<td>
-    <form method="post" style="display:inline;">
-        <input type="hidden" name="user_id" value="<?php echo $u['id']; ?>">
-        <select name="prompt_set_id">
-            <?php foreach ($promptSets as $set): ?>
-                <option value="<?php echo $set['id']; ?>" <?php if($set['id']==$u['prompt_set_id']) echo 'selected'; ?>><?php echo htmlspecialchars($set['nombre']); ?></option>
-            <?php endforeach; ?>
-        </select>
-        <button type="submit" name="prompt_update">Guardar</button>
-    </form>
-</td>
-<td><a href="?delete_user=<?php echo $u['id']; ?>" onclick="return confirm('Eliminar usuario?')">Eliminar</a></td>
-</tr>
-<?php endforeach; ?>
-</table>
-<h2>Preguntas</h2>
-<table>
-<tr><th>ID</th><th>Pregunta</th><th>Acciones</th></tr>
-<?php foreach ($questions as $q): ?>
-<tr>
-<form method="post">
-<td><?php echo $q['id']; ?><input type="hidden" name="edit_id" value="<?php echo $q['id']; ?>"></td>
-<td><input type="text" name="edit_text" value="<?php echo htmlspecialchars($q['texto_pregunta']); ?>" style="width:80%"></td>
-<td>
-<button type="submit">Guardar</button>
-<a href="?del_question=<?php echo $q['id']; ?>" onclick="return confirm('Eliminar pregunta?')">Eliminar</a>
-</td>
-</form>
-</tr>
-<?php endforeach; ?>
-</table>
-<h3>Nueva pregunta</h3>
-<form method="post">
-<input type="text" name="new_question" style="width:60%">
-<button type="submit">Agregar</button>
-</form>
 
-<h2>Prompts</h2>
-<h3>Conjuntos</h3>
-<table>
-<tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr>
-<?php foreach ($promptSets as $pset): ?>
-<tr>
-<form method="post" action="?prompt_set=<?php echo $pset['id']; ?>">
-<td><?php echo $pset['id']; ?><input type="hidden" name="set_id" value="<?php echo $pset['id']; ?>"></td>
-<td><input type="text" name="set_name" value="<?php echo htmlspecialchars($pset['nombre']); ?>"></td>
-<td>
-<button type="submit" name="rename_set">Guardar</button>
-<a href="?del_set=<?php echo $pset['id']; ?>" onclick="return confirm('Eliminar set?')">Eliminar</a>
-<a href="?prompt_set=<?php echo $pset['id']; ?>">Ver mensajes</a>
-</td>
-</form>
-</tr>
-<?php endforeach; ?>
-</table>
-<form method="post">
-<input type="text" name="new_set_name" placeholder="Nuevo conjunto">
-<button type="submit" name="add_set">Crear</button>
-</form>
+<!-- Header -->
+<header class="admin-header">
+    <div class="header-content">
+        <h1 class="admin-title">
+            <i class="fas fa-shield-alt"></i>
+            Panel de Administración
+        </h1>
+        <div class="admin-actions">
+            <a href="chat.php" class="btn">
+                <i class="fas fa-comments"></i>
+                Ir al Chat
+            </a>
+            <a href="logout.php" class="btn btn-danger">
+                <i class="fas fa-sign-out-alt"></i>
+                Cerrar Sesión
+            </a>
+        </div>
+    </div>
+</header>
 
-<?php if ($selectedSet): ?>
-<h3>Mensajes del set <?php echo $selectedSet; ?></h3>
-<table>
-<tr><th>Orden</th><th>Rol</th><th>Contenido</th><th>Acciones</th></tr>
-<?php foreach ($promptLines as $line): ?>
-<tr>
-<form method="post" action="?prompt_set=<?php echo $selectedSet; ?>">
-<td>
-<input type="hidden" name="line_id" value="<?php echo $line['id']; ?>">
-<input type="number" name="line_order" value="<?php echo $line['orden']; ?>" style="width:50px">
-</td>
-<td>
-<select name="line_role">
-<option value="system" <?php if($line['role']=='system') echo 'selected'; ?>>system</option>
-<option value="assistant" <?php if($line['role']=='assistant') echo 'selected'; ?>>assistant</option>
-<option value="user" <?php if($line['role']=='user') echo 'selected'; ?>>user</option>
-</select>
-</td>
-<td><textarea name="line_content" rows="2" cols="60"><?php echo htmlspecialchars($line['content']); ?></textarea></td>
-<td>
-<button type="submit" name="edit_line">Guardar</button>
-<a href="?prompt_set=<?php echo $selectedSet; ?>&del_line=<?php echo $line['id']; ?>" onclick="return confirm('Eliminar mensaje?')">Eliminar</a>
-</td>
-</form>
-</tr>
-<?php endforeach; ?>
-</table>
-<form method="post" action="?prompt_set=<?php echo $selectedSet; ?>">
-<input type="number" name="line_order" value="<?php echo count($promptLines)+1; ?>" style="width:50px">
-<select name="line_role">
-<option value="system">system</option>
-<option value="assistant">assistant</option>
-<option value="user">user</option>
-</select>
-<input type="text" name="line_content" style="width:60%">
-<button type="submit" name="add_line">Agregar</button>
-</form>
-<?php endif; ?>
+<!-- Main Container -->
+<div class="admin-container">
+    
+    <!-- Stats Overview -->
+    <div class="stats-grid">
+        <div class="stat-card">
+            <div class="stat-number"><?php echo count($users); ?></div>
+            <div class="stat-label">
+                <i class="fas fa-users"></i> Usuarios Totales
+            </div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-number"><?php echo count(array_filter($users, fn($u) => $u['es_admin'])); ?></div>
+            <div class="stat-label">
+                <i class="fas fa-user-shield"></i> Administradores
+            </div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-number"><?php echo count($questions); ?></div>
+            <div class="stat-label">
+                <i class="fas fa-question-circle"></i> Preguntas
+            </div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-number"><?php echo count($promptSets); ?></div>
+            <div class="stat-label">
+                <i class="fas fa-cogs"></i> Sets de Prompts
+            </div>
+        </div>
+    </div>
+
+    <!-- Tab Navigation -->
+    <div class="tab-navigation">
+        <button class="tab-btn active" onclick="showTab('users')">
+            <i class="fas fa-users"></i> Usuarios
+        </button>
+        <button class="tab-btn" onclick="showTab('questions')">
+            <i class="fas fa-question-circle"></i> Preguntas
+        </button>
+        <button class="tab-btn" onclick="showTab('prompts')">
+            <i class="fas fa-cogs"></i> Prompts
+        </button>
+    </div>
+
+    <!-- Users Tab -->
+    <div id="users-tab" class="tab-content active">
+        <div class="card">
+            <div class="card-header">
+                <h2 class="card-title">
+                    <i class="fas fa-users"></i>
+                    Gestión de Usuarios
+                </h2>
+            </div>
+            
+            <?php if (!empty($users)): ?>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Usuario</th>
+                            <th>Email</th>
+                            <th>Teléfono</th>
+                            <th>Rol</th>
+                            <th>Prompt Set</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($users as $u): ?>
+                        <tr>
+                            <td><?php echo $u['id']; ?></td>
+                            <td>
+                                <strong><?php echo htmlspecialchars($u['nombre'].' '.$u['apellido']); ?></strong>
+                            </td>
+                            <td><?php echo htmlspecialchars($u['email']); ?></td>
+                            <td><?php echo htmlspecialchars($u['telefono'] ?: 'No especificado'); ?></td>
+                            <td>
+                                <?php if ($u['es_admin']): ?>
+                                    <span class="user-badge">
+                                        <i class="fas fa-crown"></i> Admin
+                                    </span>
+                                <?php else: ?>
+                                    <span class="user-badge" style="background: rgba(52, 73, 94, 0.3); color: var(--text-muted);">
+                                        <i class="fas fa-user"></i> Usuario
+                                    </span>
+                                <?php endif; ?>
+                            </td>
+                            <td>
+                                <form method="post" class="form-inline">
+                                    <input type="hidden" name="user_id" value="<?php echo $u['id']; ?>">
+                                    <select name="prompt_set_id" class="form-select">
+                                        <?php foreach ($promptSets as $set): ?>
+                                            <option value="<?php echo $set['id']; ?>" <?php if($set['id']==$u['prompt_set_id']) echo 'selected'; ?>>
+                                                <?php echo htmlspecialchars($set['nombre']); ?>
+                                            </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                    <button type="submit" name="prompt_update" class="btn btn-success">
+                                        <i class="fas fa-save"></i>
+                                    </button>
+                                </form>
+                            </td>
+                            <td>
+                                <a href="?delete_user=<?php echo $u['id']; ?>" 
+                                   class="btn btn-danger" 
+                                   onclick="return confirm('¿Estás seguro de eliminar este usuario?')">
+                                    <i class="fas fa-trash"></i>
+                                </a>
+                            </td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php else: ?>
+                <div class="empty-state">
+                    <i class="fas fa-users"></i>
+                    <h3>No hay usuarios registrados</h3>
+                    <p>Los usuarios aparecerán aquí cuando se registren en el sistema.</p>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <!-- Questions Tab -->
+    <div id="questions-tab" class="tab-content">
+        <div class="card">
+            <div class="card-header">
+                <h2 class="card-title">
+                    <i class="fas fa-question-circle"></i>
+                    Gestión de Preguntas
+                </h2>
+            </div>
+            
+            <!-- Add New Question -->
+            <form method="post" class="form-inline" style="margin-bottom: 1.5rem;">
+                <input type="text" name="new_question" class="form-input" placeholder="Escribe una nueva pregunta..." required>
+                <button type="submit" class="btn btn-primary">
+                    <i class="fas fa-plus"></i> Agregar
+                </button>
+            </form>
+            
+            <?php if (!empty($questions)): ?>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Pregunta</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($questions as $q): ?>
+                        <tr>
+                            <form method="post">
+                                <td><?php echo $q['id']; ?></td>
+                                <td>
+                                    <input type="hidden" name="edit_id" value="<?php echo $q['id']; ?>">
+                                    <input type="text" name="edit_text" value="<?php echo htmlspecialchars($q['texto_pregunta']); ?>" class="form-input">
+                                </td>
+                                <td>
+                                    <div style="display: flex; gap: 0.5rem;">
+                                        <button type="submit" class="btn btn-success">
+                                            <i class="fas fa-save"></i> Guardar
+                                        </button>
+                                        <a href="?del_question=<?php echo $q['id']; ?>" 
+                                           class="btn btn-danger" 
+                                           onclick="return confirm('¿Eliminar esta pregunta?')">
+                                            <i class="fas fa-trash"></i>
+                                        </a>
+                                    </div>
+                                </td>
+                            </form>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php else: ?>
+                <div class="empty-state">
+                    <i class="fas fa-question-circle"></i>
+                    <h3>No hay preguntas configuradas</h3>
+                    <p>Agrega preguntas para que aparezcan en el sistema.</p>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <!-- Prompts Tab -->
+    <div id="prompts-tab" class="tab-content">
+        <div class="card">
+            <div class="card-header">
+                <h2 class="card-title">
+                    <i class="fas fa-cogs"></i>
+                    Gestión de Prompts
+                </h2>
+            </div>
+            
+            <!-- Add New Set -->
+            <form method="post" class="form-inline" style="margin-bottom: 1.5rem;">
+                <input type="text" name="new_set_name" class="form-input" placeholder="Nombre del nuevo conjunto..." required>
+                <button type="submit" name="add_set" class="btn btn-primary">
+                    <i class="fas fa-plus"></i> Crear Set
+                </button>
+            </form>
+            
+            <?php if (!empty($promptSets)): ?>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Nombre del Conjunto</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($promptSets as $pset): ?>
+                        <tr>
+                            <form method="post" action="?prompt_set=<?php echo $pset['id']; ?>">
+                                <td><?php echo $pset['id']; ?></td>
+                                <td>
+                                    <input type="hidden" name="set_id" value="<?php echo $pset['id']; ?>">
+                                    <input type="text" name="set_name" value="<?php echo htmlspecialchars($pset['nombre']); ?>" class="form-input">
+                                </td>
+                                <td>
+                                    <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                                        <button type="submit" name="rename_set" class="btn btn-success">
+                                            <i class="fas fa-save"></i>
+                                        </button>
+                                        <a href="?prompt_set=<?php echo $pset['id']; ?>" class="btn">
+                                            <i class="fas fa-eye"></i> Ver
+                                        </a>
+                                        <a href="?del_set=<?php echo $pset['id']; ?>" 
+                                           class="btn btn-danger" 
+                                           onclick="return confirm('¿Eliminar este conjunto?')">
+                                            <i class="fas fa-trash"></i>
+                                        </a>
+                                    </div>
+                                </td>
+                            </form>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php else: ?>
+                <div class="empty-state">
+                    <i class="fas fa-cogs"></i>
+                    <h3>No hay conjuntos de prompts</h3>
+                    <p>Crea conjuntos de prompts para configurar el comportamiento del chat.</p>
+                </div>
+            <?php endif; ?>
+        </div>
+
+        <!-- Prompt Lines for Selected Set -->
+        <?php if ($selectedSet): ?>
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">
+                    <i class="fas fa-list"></i>
+                    Mensajes del conjunto: <?php echo htmlspecialchars($selectedSetName); ?>
+                </h3>
+                <a href="admin.php" class="btn">
+                    <i class="fas fa-arrow-left"></i> Volver
+                </a>
+            </div>
+            
+            <!-- Add New Line -->
+            <form method="post" action="?prompt_set=<?php echo $selectedSet; ?>" class="form-inline" style="margin-bottom: 1.5rem;">
+                <input type="number" name="line_order" value="<?php echo count($promptLines)+1; ?>" class="form-input" style="max-width: 80px;" min="1">
+                <select name="line_role" class="form-select" style="max-width: 120px;">
+                    <option value="system">System</option>
+                    <option value="assistant">Assistant</option>
+                    <option value="user">User</option>
+                </select>
+                <input type="text" name="line_content" class="form-input" placeholder="Contenido del mensaje..." required>
+                <button type="submit" name="add_line" class="btn btn-primary">
+                    <i class="fas fa-plus"></i> Agregar
+                </button>
+            </form>
+            
+            <?php if (!empty($promptLines)): ?>
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Orden</th>
+                            <th>Rol</th>
+                            <th>Contenido</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($promptLines as $line): ?>
+                        <tr>
+                            <form method="post" action="?prompt_set=<?php echo $selectedSet; ?>">
+                                <td>
+                                    <input type="hidden" name="line_id" value="<?php echo $line['id']; ?>">
+                                    <input type="number" name="line_order" value="<?php echo $line['orden']; ?>" class="form-input" style="max-width: 60px;" min="1">
+                                </td>
+                                <td>
+                                    <select name="line_role" class="form-select">
+                                        <option value="system" <?php if($line['role']=='system') echo 'selected'; ?>>System</option>
+                                        <option value="assistant" <?php if($line['role']=='assistant') echo 'selected'; ?>>Assistant</option>
+                                        <option value="user" <?php if($line['role']=='user') echo 'selected'; ?>>User</option>
+                                    </select>
+                                    <span class="role-tag role-<?php echo $line['role']; ?>" style="margin-left: 0.5rem;">
+                                        <?php echo ucfirst($line['role']); ?>
+                                    </span>
+                                </td>
+                                <td>
+                                    <textarea name="line_content" rows="3" class="form-textarea"><?php echo htmlspecialchars($line['content']); ?></textarea>
+                                </td>
+                                <td>
+                                    <div style="display: flex; gap: 0.5rem; flex-direction: column;">
+                                        <button type="submit" name="edit_line" class="btn btn-success">
+                                            <i class="fas fa-save"></i> Guardar
+                                        </button>
+                                        <a href="?prompt_set=<?php echo $selectedSet; ?>&del_line=<?php echo $line['id']; ?>" 
+                                           class="btn btn-danger" 
+                                           onclick="return confirm('¿Eliminar este mensaje?')">
+                                            <i class="fas fa-trash"></i>
+                                        </a>
+                                    </div>
+                                </td>
+                            </form>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php else: ?>
+                <div class="empty-state">
+                    <i class="fas fa-list"></i>
+                    <h3>No hay mensajes en este conjunto</h3>
+                    <p>Agrega mensajes para configurar el comportamiento del chat.</p>
+                </div>
+            <?php endif; ?>
+        </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<script>
+// Tab functionality
+function showTab(tabName) {
+    // Hide all tab contents
+    document.querySelectorAll('.tab-content').forEach(content => {
+        content.classList.remove('active');
+    });
+    
+    // Remove active class from all tab buttons
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.classList.remove('active');
+    });
+    
+    // Show selected tab content
+    document.getElementById(tabName + '-tab').classList.add('active');
+    
+    // Add active class to clicked button
+    event.target.classList.add('active');
+}
+
+// Auto-save functionality for forms
+document.addEventListener('DOMContentLoaded', function() {
+    // Add loading states to forms
+    document.querySelectorAll('form').forEach(form => {
+        form.addEventListener('submit', function() {
+            const submitBtn = this.querySelector('button[type="submit"]');
+            if (submitBtn) {
+                const originalText = submitBtn.innerHTML;
+                submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Guardando...';
+                submitBtn.disabled = true;
+                
+                // Re-enable after 3 seconds if still on page
+                setTimeout(() => {
+                    submitBtn.innerHTML = originalText;
+                    submitBtn.disabled = false;
+                }, 3000);
+            }
+        });
+    });
+    
+    // Auto-resize textareas
+    document.querySelectorAll('textarea').forEach(textarea => {
+        textarea.addEventListener('input', function() {
+            this.style.height = 'auto';
+            this.style.height = this.scrollHeight + 'px';
+        });
+        
+        // Initial resize
+        textarea.style.height = textarea.scrollHeight + 'px';
+    });
+    
+    // Confirm deletion dialogs with more context
+    document.querySelectorAll('a[onclick*="confirm"]').forEach(link => {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            
+            let message = 'Esta acción no se puede deshacer.';
+            if (this.href.includes('delete_user')) {
+                message = '¿Estás seguro de eliminar este usuario?\n\nSe eliminarán todos sus datos y conversaciones.';
+            } else if (this.href.includes('del_question')) {
+                message = '¿Estás seguro de eliminar esta pregunta?\n\nYa no estará disponible en el sistema.';
+            } else if (this.href.includes('del_set')) {
+                message = '¿Estás seguro de eliminar este conjunto?\n\nSe eliminarán todos los mensajes asociados.';
+            } else if (this.href.includes('del_line')) {
+                message = '¿Estás seguro de eliminar este mensaje?\n\nEsto puede afectar el comportamiento del chat.';
+            }
+            
+            if (confirm(message)) {
+                // Show loading state
+                this.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Eliminando...';
+                this.style.pointerEvents = 'none';
+                window.location.href = this.href;
+            }
+        });
+    });
+    
+    // Success/Error notifications
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('success')) {
+        showNotification('Operación completada exitosamente', 'success');
+    }
+    if (urlParams.has('error')) {
+        showNotification('Ocurrió un error al procesar la solicitud', 'error');
+    }
+    
+    // Auto-focus on inputs when tabs change
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.addEventListener('click', function() {
+            setTimeout(() => {
+                const activeTab = document.querySelector('.tab-content.active');
+                const firstInput = activeTab.querySelector('input[type="text"], textarea');
+                if (firstInput) {
+                    firstInput.focus();
+                }
+            }, 100);
+        });
+    });
+    
+    // Enhanced form validation
+    document.querySelectorAll('input[required], textarea[required]').forEach(field => {
+        field.addEventListener('invalid', function() {
+            this.style.borderColor = 'var(--error-red)';
+            this.style.boxShadow = '0 0 10px rgba(231, 76, 60, 0.3)';
+        });
+        
+        field.addEventListener('input', function() {
+            if (this.validity.valid) {
+                this.style.borderColor = 'var(--success-green)';
+                this.style.boxShadow = '0 0 10px rgba(39, 174, 96, 0.3)';
+            }
+        });
+    });
+    
+    // Smart table sorting
+    document.querySelectorAll('.data-table th').forEach(header => {
+        header.style.cursor = 'pointer';
+        header.addEventListener('click', function() {
+            sortTable(this);
+        });
+    });
+});
+
+// Notification system
+function showNotification(message, type = 'success') {
+    const notification = document.createElement('div');
+    notification.className = `notification ${type}`;
+    notification.innerHTML = `
+        <i class="fas fa-${type === 'success' ? 'check-circle' : 'exclamation-triangle'}"></i>
+        ${message}
+    `;
+    
+    document.body.appendChild(notification);
+    
+    setTimeout(() => {
+        notification.style.opacity = '0';
+        notification.style.transform = 'translateX(100%)';
+        setTimeout(() => notification.remove(), 300);
+    }, 3000);
+}
+
+// Table sorting function
+function sortTable(header) {
+    const table = header.closest('table');
+    const tbody = table.querySelector('tbody');
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    const columnIndex = Array.from(header.parentNode.children).indexOf(header);
+    
+    // Determine sort direction
+    const isAscending = !header.classList.contains('sort-asc');
+    
+    // Clear previous sort indicators
+    header.parentNode.querySelectorAll('th').forEach(th => {
+        th.classList.remove('sort-asc', 'sort-desc');
+    });
+    
+    // Add sort indicator
+    header.classList.add(isAscending ? 'sort-asc' : 'sort-desc');
+    
+    // Sort rows
+    rows.sort((a, b) => {
+        const aText = a.children[columnIndex].textContent.trim();
+        const bText = b.children[columnIndex].textContent.trim();
+        
+        // Check if values are numbers
+        const aNum = parseFloat(aText);
+        const bNum = parseFloat(bText);
+        
+        if (!isNaN(aNum) && !isNaN(bNum)) {
+            return isAscending ? aNum - bNum : bNum - aNum;
+        }
+        
+        // String comparison
+        return isAscending ? aText.localeCompare(bText) : bText.localeCompare(aText);
+    });
+    
+    // Re-append sorted rows
+    rows.forEach(row => tbody.appendChild(row));
+}
+
+// Keyboard shortcuts
+document.addEventListener('keydown', function(e) {
+    // Ctrl/Cmd + S to save current form
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        const activeTab = document.querySelector('.tab-content.active');
+        const form = activeTab.querySelector('form');
+        if (form) {
+            form.submit();
+        }
+    }
+    
+    // Escape to close modals or reset forms
+    if (e.key === 'Escape') {
+        document.querySelectorAll('input[type="text"], textarea').forEach(field => {
+            if (document.activeElement === field) {
+                field.blur();
+            }
+        });
+    }
+});
+
+// Auto-save drafts for textareas (simple localStorage implementation)
+document.querySelectorAll('textarea').forEach(textarea => {
+    const key = `draft_${textarea.name}_${window.location.pathname}`;
+    
+    // Load saved draft
+    const savedDraft = localStorage.getItem(key);
+    if (savedDraft && !textarea.value.trim()) {
+        textarea.value = savedDraft;
+        textarea.style.borderColor = 'var(--warning-orange)';
+        textarea.title = 'Borrador guardado automáticamente';
+    }
+    
+    // Save draft on input
+    textarea.addEventListener('input', function() {
+        localStorage.setItem(key, this.value);
+        this.style.borderColor = 'var(--warning-orange)';
+        this.title = 'Borrador guardado automáticamente';
+    });
+    
+    // Clear draft on successful submit
+    textarea.closest('form').addEventListener('submit', function() {
+        localStorage.removeItem(key);
+    });
+});
+
+// Enhanced user experience features
+document.addEventListener('DOMContentLoaded', function() {
+    // Add tooltips to action buttons
+    document.querySelectorAll('.btn').forEach(btn => {
+        if (!btn.title && btn.querySelector('i')) {
+            const icon = btn.querySelector('i').className;
+            if (icon.includes('fa-save')) btn.title = 'Guardar cambios';
+            if (icon.includes('fa-trash')) btn.title = 'Eliminar elemento';
+            if (icon.includes('fa-eye')) btn.title = 'Ver detalles';
+            if (icon.includes('fa-plus')) btn.title = 'Agregar nuevo';
+            if (icon.includes('fa-arrow-left')) btn.title = 'Volver';
+        }
+    });
+    
+    // Highlight unsaved changes
+    document.querySelectorAll('input, textarea, select').forEach(field => {
+        const originalValue = field.value;
+        field.addEventListener('input', function() {
+            if (this.value !== originalValue) {
+                this.style.backgroundColor = 'rgba(241, 196, 15, 0.1)';
+                this.style.borderColor = 'var(--warning-orange)';
+            } else {
+                this.style.backgroundColor = '';
+                this.style.borderColor = '';
+            }
+        });
+    });
+});
+</script>
+
 </body>
 </html>

--- a/admin.php
+++ b/admin.php
@@ -1,0 +1,100 @@
+<?php
+session_start();
+require 'db.php';
+
+if (!isset($_SESSION['usuario_id']) || empty($_SESSION['es_admin'])) {
+    header('Location: login.php');
+    exit;
+}
+
+// Handle user deletion
+if (isset($_GET['delete_user'])) {
+    $stmt = $pdo->prepare('DELETE FROM usuarios WHERE id = ?');
+    $stmt->execute([$_GET['delete_user']]);
+}
+
+// Handle question add/update/delete
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['new_question'])) {
+        $stmt = $pdo->prepare('INSERT INTO preguntas_admin (texto_pregunta) VALUES (?)');
+        $stmt->execute([$_POST['new_question']]);
+    }
+    if (isset($_POST['edit_id']) && isset($_POST['edit_text'])) {
+        $stmt = $pdo->prepare('UPDATE preguntas_admin SET texto_pregunta = ? WHERE id = ?');
+        $stmt->execute([$_POST['edit_text'], $_POST['edit_id']]);
+    }
+    if (isset($_POST['prompt_update'])) {
+        $stmt = $pdo->prepare('UPDATE usuarios SET prompt_set_id = ? WHERE id = ?');
+        $stmt->execute([$_POST['prompt_set_id'], $_POST['user_id']]);
+    }
+}
+if (isset($_GET['del_question'])) {
+    $stmt = $pdo->prepare('DELETE FROM preguntas_admin WHERE id = ?');
+    $stmt->execute([$_GET['del_question']]);
+}
+
+$users = $pdo->query('SELECT id, nombre, apellido, email, telefono, es_admin, prompt_set_id FROM usuarios')->fetchAll();
+$promptSets = $pdo->query('SELECT id, nombre FROM prompt_sets ORDER BY id')->fetchAll();
+$questions = $pdo->query('SELECT id, texto_pregunta FROM preguntas_admin ORDER BY id')->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Admin</title>
+<style>
+table {border-collapse: collapse; width:100%;}
+th,td{border:1px solid #ccc; padding:4px;}
+</style>
+</head>
+<body>
+<h1>Panel de Administración</h1>
+<p><a href="logout.php">Cerrar sesión</a></p>
+<h2>Usuarios</h2>
+<table>
+<tr><th>ID</th><th>Nombre</th><th>Email</th><th>Teléfono</th><th>Admin</th><th>Prompt</th><th>Acciones</th></tr>
+<?php foreach ($users as $u): ?>
+<tr>
+<td><?php echo $u['id']; ?></td>
+<td><?php echo htmlspecialchars($u['nombre'].' '.$u['apellido']); ?></td>
+<td><?php echo htmlspecialchars($u['email']); ?></td>
+<td><?php echo htmlspecialchars($u['telefono']); ?></td>
+<td><?php echo $u['es_admin'] ? 'Sí' : 'No'; ?></td>
+<td>
+    <form method="post" style="display:inline;">
+        <input type="hidden" name="user_id" value="<?php echo $u['id']; ?>">
+        <select name="prompt_set_id">
+            <?php foreach ($promptSets as $set): ?>
+                <option value="<?php echo $set['id']; ?>" <?php if($set['id']==$u['prompt_set_id']) echo 'selected'; ?>><?php echo htmlspecialchars($set['nombre']); ?></option>
+            <?php endforeach; ?>
+        </select>
+        <button type="submit" name="prompt_update">Guardar</button>
+    </form>
+</td>
+<td><a href="?delete_user=<?php echo $u['id']; ?>" onclick="return confirm('Eliminar usuario?')">Eliminar</a></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<h2>Preguntas</h2>
+<table>
+<tr><th>ID</th><th>Pregunta</th><th>Acciones</th></tr>
+<?php foreach ($questions as $q): ?>
+<tr>
+<form method="post">
+<td><?php echo $q['id']; ?><input type="hidden" name="edit_id" value="<?php echo $q['id']; ?>"></td>
+<td><input type="text" name="edit_text" value="<?php echo htmlspecialchars($q['texto_pregunta']); ?>" style="width:80%"></td>
+<td>
+<button type="submit">Guardar</button>
+<a href="?del_question=<?php echo $q['id']; ?>" onclick="return confirm('Eliminar pregunta?')">Eliminar</a>
+</td>
+</form>
+</tr>
+<?php endforeach; ?>
+</table>
+<h3>Nueva pregunta</h3>
+<form method="post">
+<input type="text" name="new_question" style="width:60%">
+<button type="submit">Agregar</button>
+</form>
+</body>
+</html>

--- a/admin.php
+++ b/admin.php
@@ -14,7 +14,10 @@ if (isset($_GET['delete_user'])) {
 }
 
 // Handle question add/update/delete
+$selectedSet = isset($_GET['prompt_set']) ? (int)$_GET['prompt_set'] : null;
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // questions
     if (isset($_POST['new_question'])) {
         $stmt = $pdo->prepare('INSERT INTO preguntas_admin (texto_pregunta) VALUES (?)');
         $stmt->execute([$_POST['new_question']]);
@@ -27,15 +30,50 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmt = $pdo->prepare('UPDATE usuarios SET prompt_set_id = ? WHERE id = ?');
         $stmt->execute([$_POST['prompt_set_id'], $_POST['user_id']]);
     }
+
+    // prompt set operations
+    if (isset($_POST['add_set'])) {
+        $stmt = $pdo->prepare('INSERT INTO prompt_sets (nombre) VALUES (?)');
+        $stmt->execute([$_POST['new_set_name']]);
+        $selectedSet = $pdo->lastInsertId();
+    }
+    if (isset($_POST['rename_set'])) {
+        $stmt = $pdo->prepare('UPDATE prompt_sets SET nombre = ? WHERE id = ?');
+        $stmt->execute([$_POST['set_name'], $_POST['set_id']]);
+    }
+
+    if (isset($_POST['add_line'])) {
+        $stmt = $pdo->prepare('INSERT INTO prompt_lines (set_id, role, content, orden) VALUES (?,?,?,?)');
+        $stmt->execute([$selectedSet, $_POST['line_role'], $_POST['line_content'], (int)$_POST['line_order']]);
+    }
+    if (isset($_POST['edit_line'])) {
+        $stmt = $pdo->prepare('UPDATE prompt_lines SET role = ?, content = ?, orden = ? WHERE id = ?');
+        $stmt->execute([$_POST['line_role'], $_POST['line_content'], (int)$_POST['line_order'], $_POST['line_id']]);
+    }
 }
 if (isset($_GET['del_question'])) {
     $stmt = $pdo->prepare('DELETE FROM preguntas_admin WHERE id = ?');
     $stmt->execute([$_GET['del_question']]);
 }
+if (isset($_GET['del_set'])) {
+    $stmt = $pdo->prepare('DELETE FROM prompt_sets WHERE id = ?');
+    $stmt->execute([$_GET['del_set']]);
+    $selectedSet = null;
+}
+if (isset($_GET['del_line']) && $selectedSet) {
+    $stmt = $pdo->prepare('DELETE FROM prompt_lines WHERE id = ? AND set_id = ?');
+    $stmt->execute([$_GET['del_line'], $selectedSet]);
+}
 
 $users = $pdo->query('SELECT id, nombre, apellido, email, telefono, es_admin, prompt_set_id FROM usuarios')->fetchAll();
 $promptSets = $pdo->query('SELECT id, nombre FROM prompt_sets ORDER BY id')->fetchAll();
 $questions = $pdo->query('SELECT id, texto_pregunta FROM preguntas_admin ORDER BY id')->fetchAll();
+$promptLines = [];
+if ($selectedSet) {
+    $stmt = $pdo->prepare('SELECT id, role, content, orden FROM prompt_lines WHERE set_id = ? ORDER BY orden');
+    $stmt->execute([$selectedSet]);
+    $promptLines = $stmt->fetchAll();
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -96,5 +134,67 @@ th,td{border:1px solid #ccc; padding:4px;}
 <input type="text" name="new_question" style="width:60%">
 <button type="submit">Agregar</button>
 </form>
+
+<h2>Prompts</h2>
+<h3>Conjuntos</h3>
+<table>
+<tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr>
+<?php foreach ($promptSets as $pset): ?>
+<tr>
+<form method="post" action="?prompt_set=<?php echo $pset['id']; ?>">
+<td><?php echo $pset['id']; ?><input type="hidden" name="set_id" value="<?php echo $pset['id']; ?>"></td>
+<td><input type="text" name="set_name" value="<?php echo htmlspecialchars($pset['nombre']); ?>"></td>
+<td>
+<button type="submit" name="rename_set">Guardar</button>
+<a href="?del_set=<?php echo $pset['id']; ?>" onclick="return confirm('Eliminar set?')">Eliminar</a>
+<a href="?prompt_set=<?php echo $pset['id']; ?>">Ver mensajes</a>
+</td>
+</form>
+</tr>
+<?php endforeach; ?>
+</table>
+<form method="post">
+<input type="text" name="new_set_name" placeholder="Nuevo conjunto">
+<button type="submit" name="add_set">Crear</button>
+</form>
+
+<?php if ($selectedSet): ?>
+<h3>Mensajes del set <?php echo $selectedSet; ?></h3>
+<table>
+<tr><th>Orden</th><th>Rol</th><th>Contenido</th><th>Acciones</th></tr>
+<?php foreach ($promptLines as $line): ?>
+<tr>
+<form method="post" action="?prompt_set=<?php echo $selectedSet; ?>">
+<td>
+<input type="hidden" name="line_id" value="<?php echo $line['id']; ?>">
+<input type="number" name="line_order" value="<?php echo $line['orden']; ?>" style="width:50px">
+</td>
+<td>
+<select name="line_role">
+<option value="system" <?php if($line['role']=='system') echo 'selected'; ?>>system</option>
+<option value="assistant" <?php if($line['role']=='assistant') echo 'selected'; ?>>assistant</option>
+<option value="user" <?php if($line['role']=='user') echo 'selected'; ?>>user</option>
+</select>
+</td>
+<td><textarea name="line_content" rows="2" cols="60"><?php echo htmlspecialchars($line['content']); ?></textarea></td>
+<td>
+<button type="submit" name="edit_line">Guardar</button>
+<a href="?prompt_set=<?php echo $selectedSet; ?>&del_line=<?php echo $line['id']; ?>" onclick="return confirm('Eliminar mensaje?')">Eliminar</a>
+</td>
+</form>
+</tr>
+<?php endforeach; ?>
+</table>
+<form method="post" action="?prompt_set=<?php echo $selectedSet; ?>">
+<input type="number" name="line_order" value="<?php echo count($promptLines)+1; ?>" style="width:50px">
+<select name="line_role">
+<option value="system">system</option>
+<option value="assistant">assistant</option>
+<option value="user">user</option>
+</select>
+<input type="text" name="line_content" style="width:60%">
+<button type="submit" name="add_line">Agregar</button>
+</form>
+<?php endif; ?>
 </body>
 </html>

--- a/chat.php
+++ b/chat.php
@@ -1,0 +1,743 @@
+<?php
+session_start();
+require 'db.php';
+require 'openai.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$usuario_id = $_SESSION['usuario_id'];
+
+// Obtener preferencias de diseño o crear valores por defecto
+$stmt = $pdo->prepare("SELECT tema, color_preferido FROM preferencias_disenio WHERE usuario_id = ? LIMIT 1");
+$stmt->execute([$usuario_id]);
+$pref = $stmt->fetch();
+if (!$pref) {
+    $pref = ['tema' => 'dark', 'color_preferido' => '#D4AF37'];
+    $stmt = $pdo->prepare("INSERT INTO preferencias_disenio (usuario_id, tema, color_preferido) VALUES (?, ?, ?)");
+    $stmt->execute([$usuario_id, $pref['tema'], $pref['color_preferido']]);
+}
+
+// Actualizar preferencias si se envían por formulario
+if (isset($_POST['tema']) && isset($_POST['color'])) {
+    $pref['tema'] = $_POST['tema'];
+    $pref['color_preferido'] = $_POST['color'];
+    $stmt = $pdo->prepare("UPDATE preferencias_disenio SET tema = ?, color_preferido = ? WHERE usuario_id = ?");
+    $stmt->execute([$pref['tema'], $pref['color_preferido'], $usuario_id]);
+}
+
+// Buscar o crear conversación
+$stmt = $pdo->prepare("SELECT id FROM conversaciones WHERE usuario_id = ? LIMIT 1");
+$stmt->execute([$usuario_id]);
+$conver = $stmt->fetch();
+if (!$conver) {
+    $stmt = $pdo->prepare("INSERT INTO conversaciones (usuario_id) VALUES (?)");
+    $stmt->execute([$usuario_id]);
+    $conver_id = $pdo->lastInsertId();
+} else {
+    $conver_id = $conver['id'];
+}
+
+// Borrar mensaje si el usuario lo solicita
+if (isset($_GET['del_msg'])) {
+    $delId = (int)$_GET['del_msg'];
+    $stmt = $pdo->prepare('SELECT m.id FROM mensajes m JOIN conversaciones c ON m.conversacion_id = c.id WHERE m.id = ? AND c.usuario_id = ? LIMIT 1');
+    $stmt->execute([$delId, $usuario_id]);
+    if ($stmt->fetch()) {
+        $del = $pdo->prepare('DELETE FROM mensajes WHERE id = ?');
+        $del->execute([$delId]);
+    }
+    header('Location: chat.php');
+    exit;
+}
+
+// Enviar mensaje
+if (isset($_POST['mensaje']) && trim($_POST['mensaje']) !== '') {
+    $mensaje = trim($_POST['mensaje']);
+    $stmt = $pdo->prepare("INSERT INTO mensajes (conversacion_id, emisor, texto) VALUES (?, 'usuario', ?)");
+    $stmt->execute([$conver_id, $mensaje]);
+
+    // Detectar preferencias de color o tema en el mensaje
+    $mensajeLower = strtolower($mensaje);
+    $colorMap = [
+        'rojo' => '#ff0000',
+        'red' => '#ff0000',
+        'verde' => '#008000',
+        'green' => '#008000',
+        'azul' => '#0000ff',
+        'blue' => '#0000ff',
+        'amarillo' => '#ffff00',
+        'yellow' => '#ffff00',
+        'naranja' => '#ffa500',
+        'orange' => '#ffa500',
+        'violeta' => '#800080',
+        'morado' => '#800080',
+        'purple' => '#800080',
+        'negro' => '#000000',
+        'black' => '#000000',
+        'blanco' => '#ffffff',
+        'white' => '#ffffff',
+        'gris' => '#808080',
+        'gray' => '#808080',
+        'grey' => '#808080',
+        'rosa' => '#ff69b4',
+        'pink' => '#ff69b4',
+        'dorado' => '#D4AF37',
+        'gold' => '#D4AF37'
+    ];
+    $newColor = null;
+    if (preg_match('/#([0-9a-f]{3,6})/i', $mensajeLower, $m)) {
+        $newColor = '#' . $m[1];
+    } elseif (isset($colorMap[$mensajeLower])) {
+        $newColor = $colorMap[$mensajeLower];
+    }
+    if ($newColor) {
+        $pref['color_preferido'] = $newColor;
+        $stmt = $pdo->prepare('UPDATE preferencias_disenio SET color_preferido = ? WHERE usuario_id = ?');
+        $stmt->execute([$newColor, $usuario_id]);
+    }
+    if (strpos($mensajeLower, 'oscuro') !== false || strpos($mensajeLower, 'dark') !== false) {
+        $pref['tema'] = 'dark';
+        $stmt = $pdo->prepare('UPDATE preferencias_disenio SET tema = ? WHERE usuario_id = ?');
+        $stmt->execute(['dark', $usuario_id]);
+    }
+    if (strpos($mensajeLower, 'claro') !== false || strpos($mensajeLower, 'light') !== false) {
+        $pref['tema'] = 'light';
+        $stmt = $pdo->prepare('UPDATE preferencias_disenio SET tema = ? WHERE usuario_id = ?');
+        $stmt->execute(['light', $usuario_id]);
+    }
+
+    // Construir historial para la API
+    $stmt = $pdo->prepare("SELECT emisor, texto FROM mensajes WHERE conversacion_id = ? ORDER BY id");
+    $stmt->execute([$conver_id]);
+    $historial = $stmt->fetchAll();
+    $messages = [];
+    foreach ($historial as $m) {
+        $messages[] = ['role' => $m['emisor'] === 'usuario' ? 'user' : 'assistant', 'content' => $m['texto']];
+    }
+
+    // Prompt inicial y preguntas base si es el primer mensaje
+    if (count($messages) === 1) {
+        $setStmt = $pdo->prepare('SELECT prompt_set_id FROM usuarios WHERE id = ?');
+        $setStmt->execute([$usuario_id]);
+        $setId = $setStmt->fetchColumn();
+        if ($setId) {
+            $pstmt = $pdo->prepare('SELECT role, content FROM prompt_lines WHERE set_id = ? ORDER BY orden');
+            $pstmt->execute([$setId]);
+            $basePrompts = [];
+            foreach ($pstmt->fetchAll() as $p) {
+                $basePrompts[] = ['role' => $p['role'], 'content' => $p['content']];
+            }
+            $messages = array_merge($basePrompts, $messages);
+        }
+    }
+
+    $respuesta = call_openai_api($messages);
+
+    $stmt = $pdo->prepare("INSERT INTO mensajes (conversacion_id, emisor, texto) VALUES (?, 'asistente', ?)");
+    $stmt->execute([$conver_id, $respuesta]);
+}
+
+// Obtener mensajes para mostrar
+$stmt = $pdo->prepare("SELECT id, emisor, texto, fecha_envio FROM mensajes WHERE conversacion_id = ? ORDER BY id");
+$stmt->execute([$conver_id]);
+$mensajes = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="es" class="<?php echo htmlspecialchars($pref['tema']); ?>">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>✨ Celestial Chat</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+<style>
+:root {
+    --user-color: <?php echo htmlspecialchars($pref['color_preferido']); ?>;
+    --primary-gold: var(--user-color);
+    --secondary-gold: var(--user-color);
+    --deep-blue: #0B1426;
+    --navy-blue: #1A2332;
+    --light-blue: #2C3E50;
+    --accent-blue: #34495E;
+    --text-light: #ECF0F1;
+    --text-muted: #BDC3C7;
+    --shadow-gold: rgba(212, 175, 55, 0.3);
+    --gradient-bg: linear-gradient(135deg, #0B1426 0%, var(--user-color) 100%);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: var(--gradient-bg);
+    color: var(--text-light);
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+body.light {
+    --deep-blue: #F8F9FA;
+    --navy-blue: #E9ECEF;
+    --light-blue: #DEE2E6;
+    --accent-blue: #CED4DA;
+    --text-light: #212529;
+    --text-muted: #6C757D;
+    --gradient-bg: linear-gradient(135deg, #F8F9FA 0%, var(--user-color) 100%);
+}
+
+/* Header */
+.header {
+    background: rgba(11, 20, 38, 0.9);
+    backdrop-filter: blur(10px);
+    padding: 1rem 2rem;
+    border-bottom: 2px solid var(--primary-gold);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-shadow: 0 4px 20px var(--shadow-gold);
+}
+
+.header h1 {
+    color: var(--secondary-gold);
+    font-size: 1.8rem;
+    font-weight: 300;
+    letter-spacing: 2px;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.header .star-icon {
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.1); opacity: 0.8; }
+}
+
+.header-actions {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.settings-btn {
+    background: transparent;
+    border: 2px solid var(--primary-gold);
+    color: var(--primary-gold);
+    padding: 0.5rem 1rem;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 0.9rem;
+}
+
+.settings-btn:hover {
+    background: var(--primary-gold);
+    color: var(--deep-blue);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px var(--shadow-gold);
+}
+
+/* Settings Panel */
+.settings-panel {
+    background: rgba(26, 35, 50, 0.95);
+    backdrop-filter: blur(15px);
+    border: 2px solid var(--primary-gold);
+    border-radius: 15px;
+    padding: 1.5rem;
+    margin: 1rem 2rem;
+    box-shadow: 0 8px 32px var(--shadow-gold);
+    display: none;
+    animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+    from { opacity: 0; transform: translateY(-20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.settings-row {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.settings-row label {
+    color: var(--secondary-gold);
+    font-weight: 500;
+    min-width: 80px;
+}
+
+.settings-row select, .settings-row input[type="color"] {
+    background: var(--accent-blue);
+    border: 2px solid var(--primary-gold);
+    color: var(--text-light);
+    padding: 0.5rem;
+    border-radius: 8px;
+    transition: all 0.3s ease;
+}
+
+.settings-row select:focus, .settings-row input[type="color"]:focus {
+    outline: none;
+    box-shadow: 0 0 10px var(--shadow-gold);
+    transform: scale(1.05);
+}
+
+/* Chat Container */
+.chat-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 120px);
+}
+
+.chat-window {
+    flex: 1;
+    background: rgba(26, 35, 50, 0.6);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    border: 2px solid var(--primary-gold);
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    overflow-y: auto;
+    box-shadow: inset 0 4px 20px rgba(0, 0, 0, 0.3);
+    scroll-behavior: smooth;
+}
+
+.chat-window::-webkit-scrollbar {
+    width: 8px;
+}
+
+.chat-window::-webkit-scrollbar-track {
+    background: rgba(11, 20, 38, 0.5);
+    border-radius: 10px;
+}
+
+.chat-window::-webkit-scrollbar-thumb {
+    background: var(--primary-gold);
+    border-radius: 10px;
+}
+
+/* Messages */
+.message-container {
+    margin: 1rem 0;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.8rem;
+    animation: fadeInUp 0.4s ease-out;
+}
+
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.message-container.user {
+    flex-direction: row-reverse;
+}
+
+.message-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    flex-shrink: 0;
+}
+
+.message-container.user .message-avatar {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    color: var(--deep-blue);
+}
+
+.message-container.assistant .message-avatar {
+    background: linear-gradient(135deg, var(--light-blue), var(--accent-blue));
+    color: var(--secondary-gold);
+}
+
+.message-content {
+    max-width: 70%;
+    position: relative;
+}
+
+.message {
+    padding: 1rem 1.5rem;
+    border-radius: 18px;
+    position: relative;
+    line-height: 1.6;
+    word-wrap: break-word;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.message-container.user .message {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    color: var(--deep-blue);
+    border-bottom-right-radius: 5px;
+}
+
+.message-container.assistant .message {
+    background: rgba(52, 73, 94, 0.8);
+    backdrop-filter: blur(10px);
+    color: var(--text-light);
+    border: 1px solid rgba(212, 175, 55, 0.3);
+    border-bottom-left-radius: 5px;
+}
+
+.message-actions {
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.message-container:hover .message-actions {
+    opacity: 1;
+}
+
+.delete-btn {
+    background: rgba(231, 76, 60, 0.9);
+    border: none;
+    color: white;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+}
+
+.delete-btn:hover {
+    background: #E74C3C;
+    transform: scale(1.1);
+}
+
+.message-time {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    margin-top: 0.3rem;
+    opacity: 0.7;
+}
+
+/* Input Area */
+.input-area {
+    background: rgba(26, 35, 50, 0.9);
+    backdrop-filter: blur(15px);
+    border-radius: 25px;
+    border: 2px solid var(--primary-gold);
+    padding: 1rem;
+    box-shadow: 0 -4px 20px var(--shadow-gold);
+}
+
+.input-form {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.message-input {
+    flex: 1;
+    background: rgba(52, 73, 94, 0.5);
+    border: 2px solid rgba(212, 175, 55, 0.3);
+    color: var(--text-light);
+    padding: 1rem 1.5rem;
+    border-radius: 25px;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+    outline: none;
+}
+
+.message-input:focus {
+    border-color: var(--primary-gold);
+    box-shadow: 0 0 15px var(--shadow-gold);
+    background: rgba(52, 73, 94, 0.8);
+}
+
+.message-input::placeholder {
+    color: var(--text-muted);
+}
+
+.send-btn {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    border: none;
+    color: var(--deep-blue);
+    padding: 1rem 1.5rem;
+    border-radius: 25px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.send-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px var(--shadow-gold);
+}
+
+.send-btn:active {
+    transform: translateY(0);
+}
+
+/* Navigation */
+.navigation {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(11, 20, 38, 0.95);
+    backdrop-filter: blur(15px);
+    border-top: 2px solid var(--primary-gold);
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    z-index: 50;
+}
+
+.nav-link {
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+    border-radius: 15px;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.nav-link:hover {
+    color: var(--primary-gold);
+    background: rgba(212, 175, 55, 0.1);
+    transform: translateY(-2px);
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .header {
+        padding: 1rem;
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    .settings-panel {
+        margin: 1rem;
+    }
+    
+    .chat-container {
+        padding: 1rem;
+        height: calc(100vh - 160px);
+    }
+    
+    .message-content {
+        max-width: 85%;
+    }
+    
+    .navigation {
+        padding: 1rem;
+        gap: 1rem;
+    }
+    
+    .nav-link span {
+        display: none;
+    }
+}
+
+/* Empty State */
+.empty-state {
+    text-align: center;
+    padding: 3rem 2rem;
+    color: var(--text-muted);
+}
+
+.empty-state i {
+    font-size: 3rem;
+    color: var(--primary-gold);
+    margin-bottom: 1rem;
+}
+
+.empty-state h3 {
+    color: var(--secondary-gold);
+    margin-bottom: 0.5rem;
+}
+</style>
+</head>
+<body class="<?php echo htmlspecialchars($pref['tema']); ?>">
+
+<!-- Header -->
+<header class="header">
+    <h1>
+        <i class="fas fa-star star-icon"></i>
+        Celestial Chat
+    </h1>
+    <div class="header-actions">
+        <button class="settings-btn" onclick="toggleSettings()">
+            <i class="fas fa-cog"></i> Configuración
+        </button>
+    </div>
+</header>
+
+<!-- Settings Panel -->
+<div id="settings-panel" class="settings-panel">
+    <form method="post">
+        <div class="settings-row">
+            <label><i class="fas fa-palette"></i> Tema:</label>
+            <select name="tema">
+                <option value="dark" <?php if($pref['tema']==='dark') echo 'selected'; ?>>🌙 Oscuro</option>
+                <option value="light" <?php if($pref['tema']==='light') echo 'selected'; ?>>☀️ Claro</option>
+            </select>
+        </div>
+        <div class="settings-row">
+            <label><i class="fas fa-paint-brush"></i> Color:</label>
+            <input type="color" name="color" value="<?php echo htmlspecialchars($pref['color_preferido']); ?>">
+            <button type="submit" class="settings-btn">
+                <i class="fas fa-save"></i> Guardar
+            </button>
+        </div>
+    </form>
+</div>
+
+<!-- Chat Container -->
+<div class="chat-container">
+    <div class="chat-window" id="chat-window">
+        <?php if (empty($mensajes)): ?>
+            <div class="empty-state">
+                <i class="fas fa-comments"></i>
+                <h3>¡Bienvenido al Chat Celestial!</h3>
+                <p>Comienza una conversación escribiendo tu primer mensaje.</p>
+            </div>
+        <?php else: ?>
+            <?php foreach ($mensajes as $m): ?>
+                <div class="message-container <?php echo $m['emisor']; ?>">
+                    <div class="message-avatar">
+                        <?php if ($m['emisor'] === 'usuario'): ?>
+                            <i class="fas fa-user"></i>
+                        <?php else: ?>
+                            <i class="fas fa-robot"></i>
+                        <?php endif; ?>
+                    </div>
+                    <div class="message-content">
+                        <div class="message">
+                            <?php echo nl2br(htmlspecialchars($m['texto'])); ?>
+                            <div class="message-actions">
+                                <button class="delete-btn" onclick="deleteMessage(<?php echo $m['id']; ?>)">
+                                    <i class="fas fa-trash"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <div class="message-time">
+                            <?php echo date('H:i', strtotime($m['fecha_envio'])); ?>
+                        </div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </div>
+    
+    <!-- Input Area -->
+    <div class="input-area">
+        <form method="post" class="input-form">
+            <input 
+                name="mensaje" 
+                class="message-input"
+                placeholder="✨ Escribe tu mensaje mágico aquí..." 
+                type="text"
+                autocomplete="off"
+                required
+            >
+            <button type="submit" class="send-btn">
+                <i class="fas fa-paper-plane"></i>
+                <span>Enviar</span>
+            </button>
+        </form>
+    </div>
+</div>
+
+<!-- Navigation -->
+<nav class="navigation">
+    <a href="profile.php" class="nav-link">
+        <i class="fas fa-user-circle"></i>
+        <span>Mi Perfil</span>
+    </a>
+    <a href="logout.php" class="nav-link">
+        <i class="fas fa-sign-out-alt"></i>
+        <span>Cerrar Sesión</span>
+    </a>
+</nav>
+
+<script>
+// Toggle Settings Panel
+function toggleSettings() {
+    const panel = document.getElementById('settings-panel');
+    panel.style.display = panel.style.display === 'none' || panel.style.display === '' ? 'block' : 'none';
+}
+
+// Delete Message
+function deleteMessage(id) {
+    if (confirm('¿Estás seguro de que quieres eliminar este mensaje?')) {
+        window.location.href = '?del_msg=' + id;
+    }
+}
+
+// Auto-scroll to bottom
+function scrollToBottom() {
+    const chatWindow = document.getElementById('chat-window');
+    chatWindow.scrollTop = chatWindow.scrollHeight;
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    const messageInput = document.querySelector('.message-input');
+    messageInput.focus();
+    scrollToBottom();
+});
+
+document.querySelector('.message-input').addEventListener('keypress', function(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        this.closest('form').submit();
+    }
+});
+
+document.addEventListener('click', function(e) {
+    const panel = document.getElementById('settings-panel');
+    const settingsBtn = document.querySelector('.settings-btn');
+    
+    if (!panel.contains(e.target) && !settingsBtn.contains(e.target)) {
+        panel.style.display = 'none';
+    }
+});
+
+let typingDots = 0;
+setInterval(() => {
+    const input = document.querySelector('.message-input');
+    if (document.activeElement === input && input.value === '') {
+        typingDots = (typingDots + 1) % 4;
+        const dots = '.'.repeat(typingDots);
+        input.placeholder = `✨ Escribe tu mensaje mágico aquí${dots}`;
+    }
+}, 500);
+</script>
+
+</body>
+</html>

--- a/db.php
+++ b/db.php
@@ -1,0 +1,23 @@
+<?php
+// db.php - Database connection using PDO
+
+$host = 'localhost';
+$db   = 'marhar345_merlin';
+$user = 'YOUR_DB_USER';
+$pass = 'YOUR_DB_PASSWORD';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    // In production you might log this error to a file instead of showing it
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
+

--- a/init_prompts.php
+++ b/init_prompts.php
@@ -1,6 +1,13 @@
 <?php
 // init_prompts.php - Load prompt sets defined in prompts.php into the database
 require 'db.php';
+
+$exists = $pdo->query('SELECT COUNT(*) FROM prompt_sets')->fetchColumn();
+if ($exists > 0) {
+    echo "Prompts ya inicializados.\n";
+    exit;
+}
+
 $promptSets = include 'prompts.php';
 
 $insertSet = $pdo->prepare('INSERT INTO prompt_sets (nombre) VALUES (?)');

--- a/init_prompts.php
+++ b/init_prompts.php
@@ -1,0 +1,20 @@
+<?php
+// init_prompts.php - Load prompt sets defined in prompts.php into the database
+require 'db.php';
+$promptSets = include 'prompts.php';
+
+$insertSet = $pdo->prepare('INSERT INTO prompt_sets (nombre) VALUES (?)');
+$insertLine = $pdo->prepare('INSERT INTO prompt_lines (set_id, role, content, orden) VALUES (?, ?, ?, ?)');
+
+$totalLines = 0;
+foreach ($promptSets as $name => $messages) {
+    $insertSet->execute([$name]);
+    $setId = $pdo->lastInsertId();
+    $order = 1;
+    foreach ($messages as $m) {
+        $insertLine->execute([$setId, $m["role"], $m["content"], $order]);
+        $order++; $totalLines++;
+    }
+    echo "Set '$name' cargado con ID $setId\n";
+}
+echo "Mensajes cargados: $totalLines\n";

--- a/login.php
+++ b/login.php
@@ -1,0 +1,40 @@
+<?php
+session_start();
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email    = trim($_POST['email']);
+    $password = $_POST['password'];
+
+    $stmt = $pdo->prepare("SELECT id, password, es_admin FROM usuarios WHERE email = ? LIMIT 1");
+    $stmt->execute([$email]);
+    $usuario = $stmt->fetch();
+
+    if ($usuario && password_verify($password, $usuario['password'])) {
+        $_SESSION['usuario_id'] = $usuario['id'];
+        $_SESSION['es_admin'] = $usuario['es_admin'];
+        $destino = $usuario['es_admin'] ? 'admin.php' : 'chat.php';
+        header('Location: ' . $destino);
+        exit;
+    } else {
+        $error = 'Credenciales incorrectas.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<form method="post">
+    <input name="email" type="email" placeholder="Email" required><br>
+    <input name="password" type="password" placeholder="Contraseña" required><br>
+    <button type="submit">Entrar</button>
+</form>
+<p style="font-size:small">Al usar este chat aceptas la <a href="privacy.php">política de privacidad</a>.</p>
+<?php if (!empty($error)) echo "<p>$error</p>"; ?>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -25,16 +25,543 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <html lang="es">
 <head>
 <meta charset="UTF-8">
-<title>Login</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>✨ Celestial Chat - Iniciar Sesión</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+<style>
+:root {
+    --primary-gold: #D4AF37;
+    --secondary-gold: #FFD700;
+    --deep-blue: #0B1426;
+    --navy-blue: #1A2332;
+    --light-blue: #2C3E50;
+    --accent-blue: #34495E;
+    --text-light: #ECF0F1;
+    --text-muted: #BDC3C7;
+    --shadow-gold: rgba(212, 175, 55, 0.3);
+    --gradient-bg: linear-gradient(135deg, #0B1426 0%, #1A2332 50%, #2C3E50 100%);
+    --error-red: #E74C3C;
+    --success-green: #27AE60;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: var(--gradient-bg);
+    color: var(--text-light);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+}
+
+/* Animated Background Stars */
+.stars {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.star {
+    position: absolute;
+    background: var(--secondary-gold);
+    border-radius: 50%;
+    animation: twinkle 2s infinite ease-in-out;
+}
+
+.star:nth-child(odd) {
+    animation-delay: 1s;
+}
+
+@keyframes twinkle {
+    0%, 100% { opacity: 0.3; transform: scale(1); }
+    50% { opacity: 1; transform: scale(1.2); }
+}
+
+/* Login Container */
+.login-container {
+    position: relative;
+    z-index: 10;
+    width: 100%;
+    max-width: 400px;
+    padding: 2rem;
+}
+
+.login-card {
+    background: rgba(26, 35, 50, 0.9);
+    backdrop-filter: blur(20px);
+    border: 2px solid var(--primary-gold);
+    border-radius: 20px;
+    padding: 3rem 2rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), 0 0 40px var(--shadow-gold);
+    text-align: center;
+    animation: slideIn 0.8s ease-out;
+}
+
+@keyframes slideIn {
+    from { 
+        opacity: 0; 
+        transform: translateY(50px) scale(0.9); 
+    }
+    to { 
+        opacity: 1; 
+        transform: translateY(0) scale(1); 
+    }
+}
+
+/* Header */
+.login-header {
+    margin-bottom: 2rem;
+}
+
+.login-title {
+    color: var(--secondary-gold);
+    font-size: 2.2rem;
+    font-weight: 300;
+    letter-spacing: 2px;
+    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.star-icon {
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.1); opacity: 0.8; }
+}
+
+.login-subtitle {
+    color: var(--text-muted);
+    font-size: 1rem;
+    font-weight: 300;
+}
+
+/* Form Styles */
+.login-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.form-group {
+    position: relative;
+}
+
+.form-input {
+    width: 100%;
+    background: rgba(52, 73, 94, 0.5);
+    border: 2px solid rgba(212, 175, 55, 0.3);
+    color: var(--text-light);
+    padding: 1rem 1rem 1rem 3rem;
+    border-radius: 15px;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+    outline: none;
+}
+
+.form-input:focus {
+    border-color: var(--primary-gold);
+    box-shadow: 0 0 20px var(--shadow-gold);
+    background: rgba(52, 73, 94, 0.8);
+    transform: translateY(-2px);
+}
+
+.form-input::placeholder {
+    color: var(--text-muted);
+    font-weight: 300;
+}
+
+.form-icon {
+    position: absolute;
+    left: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--primary-gold);
+    font-size: 1.1rem;
+}
+
+/* Login Button */
+.login-btn {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    border: none;
+    color: var(--deep-blue);
+    padding: 1rem 2rem;
+    border-radius: 15px;
+    cursor: pointer;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 1px;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-top: 1rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.login-btn:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 30px var(--shadow-gold);
+}
+
+.login-btn:active {
+    transform: translateY(-1px);
+}
+
+.login-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+    transition: left 0.5s;
+}
+
+.login-btn:hover::before {
+    left: 100%;
+}
+
+/* Error Messages */
+.error-message {
+    background: rgba(231, 76, 60, 0.1);
+    border: 1px solid var(--error-red);
+    color: var(--error-red);
+    padding: 1rem;
+    border-radius: 10px;
+    margin-top: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    animation: shake 0.5s ease-in-out;
+}
+
+@keyframes shake {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-5px); }
+    75% { transform: translateX(5px); }
+}
+
+/* Footer Links */
+.login-footer {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid rgba(212, 175, 55, 0.2);
+}
+
+.privacy-notice {
+    text-align: center;
+    margin-bottom: 1rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+}
+
+.privacy-link {
+    color: var(--primary-gold);
+    text-decoration: none;
+    transition: all 0.3s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 6px;
+}
+
+.privacy-link:hover {
+    color: var(--secondary-gold);
+    background: rgba(212, 175, 55, 0.1);
+    transform: translateY(-1px);
+}
+
+.footer-links {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.footer-link {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: all 0.3s ease;
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+}
+
+.footer-link:hover {
+    color: var(--primary-gold);
+    background: rgba(212, 175, 55, 0.1);
+    transform: translateY(-2px);
+}
+
+/* Loading State */
+.loading {
+    pointer-events: none;
+}
+
+.loading .login-btn {
+    background: var(--accent-blue);
+    color: var(--text-muted);
+}
+
+.loading-spinner {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border: 2px solid transparent;
+    border-top: 2px solid currentColor;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* Responsive Design */
+@media (max-width: 480px) {
+    .login-container {
+        padding: 1rem;
+    }
+    
+    .login-card {
+        padding: 2rem 1.5rem;
+    }
+    
+    .login-title {
+        font-size: 1.8rem;
+    }
+    
+    .form-input {
+        padding: 0.8rem 0.8rem 0.8rem 2.5rem;
+    }
+    
+    .form-icon {
+        left: 0.8rem;
+    }
+}
+
+/* Welcome Animation */
+.welcome-text {
+    position: absolute;
+    top: 10%;
+    left: 50%;
+    transform: translateX(-50%);
+    color: var(--primary-gold);
+    font-size: 1.2rem;
+    font-weight: 300;
+    letter-spacing: 1px;
+    opacity: 0.7;
+    z-index: 5;
+}
+
+/* Particle Effect */
+.particle {
+    position: absolute;
+    background: var(--primary-gold);
+    border-radius: 50%;
+    pointer-events: none;
+}
+</style>
 </head>
 <body>
-<h1>Login</h1>
-<form method="post">
-    <input name="email" type="email" placeholder="Email" required><br>
-    <input name="password" type="password" placeholder="Contraseña" required><br>
-    <button type="submit">Entrar</button>
-</form>
-<p style="font-size:small">Al usar este chat aceptas la <a href="privacy.php">política de privacidad</a>.</p>
-<?php if (!empty($error)) echo "<p>$error</p>"; ?>
+
+<!-- Animated Stars Background -->
+<div class="stars" id="stars"></div>
+
+<!-- Welcome Text -->
+<div class="welcome-text">
+    Bienvenido al Chat Celestial
+</div>
+
+<!-- Login Container -->
+<div class="login-container">
+    <div class="login-card">
+        <!-- Header -->
+        <div class="login-header">
+            <h1 class="login-title">
+                <i class="fas fa-star star-icon"></i>
+                Celestial Chat
+            </h1>
+            <p class="login-subtitle">Inicia sesión para acceder a tu chat mágico</p>
+        </div>
+
+        <!-- Login Form -->
+        <form method="post" class="login-form" id="loginForm">
+            <div class="form-group">
+                <i class="fas fa-envelope form-icon"></i>
+                <input 
+                    name="email" 
+                    type="email" 
+                    class="form-input"
+                    placeholder="Tu correo electrónico" 
+                    required
+                    autocomplete="email"
+                >
+            </div>
+
+            <div class="form-group">
+                <i class="fas fa-lock form-icon"></i>
+                <input 
+                    name="password" 
+                    type="password" 
+                    class="form-input"
+                    placeholder="Tu contraseña secreta" 
+                    required
+                    autocomplete="current-password"
+                >
+            </div>
+
+            <button type="submit" class="login-btn" id="loginBtn">
+                <i class="fas fa-sign-in-alt"></i>
+                <span>Entrar al Chat</span>
+            </button>
+        </form>
+
+        <!-- Error Message -->
+        <?php if (!empty($error)): ?>
+            <div class="error-message">
+                <i class="fas fa-exclamation-triangle"></i>
+                <?php echo htmlspecialchars($error); ?>
+            </div>
+        <?php endif; ?>
+
+        <!-- Footer -->
+        <div class="login-footer">
+            <div class="privacy-notice">
+                <p>
+                    Al usar este chat celestial aceptas nuestra 
+                    <a href="privacy.php" class="privacy-link">
+                        <i class="fas fa-shield-alt"></i>
+                        Política de Privacidad
+                    </a>
+                </p>
+            </div>
+            <div class="footer-links">
+                <a href="register.php" class="footer-link">
+                    <i class="fas fa-user-plus"></i> Crear cuenta
+                </a>
+                <a href="forgot-password.php" class="footer-link">
+                    <i class="fas fa-key"></i> ¿Olvidaste tu contraseña?
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+// Create animated stars
+function createStars() {
+    const starsContainer = document.getElementById('stars');
+    const numStars = 50;
+    
+    for (let i = 0; i < numStars; i++) {
+        const star = document.createElement('div');
+        star.className = 'star';
+        star.style.left = Math.random() * 100 + '%';
+        star.style.top = Math.random() * 100 + '%';
+        star.style.width = Math.random() * 3 + 1 + 'px';
+        star.style.height = star.style.width;
+        star.style.animationDelay = Math.random() * 2 + 's';
+        starsContainer.appendChild(star);
+    }
+}
+
+// Form submission with loading state
+document.getElementById('loginForm').addEventListener('submit', function(e) {
+    const form = this;
+    const btn = document.getElementById('loginBtn');
+    const btnText = btn.querySelector('span');
+    const btnIcon = btn.querySelector('i');
+    
+    // Add loading state
+    form.classList.add('loading');
+    btnIcon.className = 'loading-spinner';
+    btnText.textContent = 'Conectando...';
+    
+    // Remove loading state after 3 seconds if form hasn't redirected
+    setTimeout(() => {
+        form.classList.remove('loading');
+        btnIcon.className = 'fas fa-sign-in-alt';
+        btnText.textContent = 'Entrar al Chat';
+    }, 3000);
+});
+
+// Focus on first input
+document.addEventListener('DOMContentLoaded', function() {
+    createStars();
+    document.querySelector('input[name="email"]').focus();
+});
+
+// Add particle effect on hover
+document.querySelectorAll('.form-input, .login-btn').forEach(element => {
+    element.addEventListener('mouseenter', function(e) {
+        createParticle(e.pageX, e.pageY);
+    });
+});
+
+function createParticle(x, y) {
+    const particle = document.createElement('div');
+    particle.className = 'particle';
+    particle.style.left = x + 'px';
+    particle.style.top = y + 'px';
+    particle.style.width = '4px';
+    particle.style.height = '4px';
+    particle.style.opacity = '0.8';
+    document.body.appendChild(particle);
+    
+    // Animate and remove particle
+    setTimeout(() => {
+        particle.style.opacity = '0';
+        particle.style.transform = 'translateY(-20px) scale(0)';
+        particle.style.transition = 'all 0.5s ease-out';
+        setTimeout(() => particle.remove(), 500);
+    }, 100);
+}
+
+// Add enter key functionality
+document.querySelectorAll('.form-input').forEach(input => {
+    input.addEventListener('keypress', function(e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            document.getElementById('loginForm').submit();
+        }
+    });
+});
+
+// Add subtle floating animation to the card
+let start = Date.now();
+function animateCard() {
+    const card = document.querySelector('.login-card');
+    const elapsed = Date.now() - start;
+    const y = Math.sin(elapsed / 1000) * 3;
+    card.style.transform = `translateY(${y}px)`;
+    requestAnimationFrame(animateCard);
+}
+animateCard();
+</script>
+
 </body>
 </html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,4 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');

--- a/logout.php
+++ b/logout.php
@@ -1,4 +1,483 @@
 <?php
 session_start();
+
+// Store user info before destroying session (for personalized goodbye)
+$was_logged_in = isset($_SESSION['usuario_id']);
+$redirect_delay = 3; // seconds
+
+// Destroy the session
 session_destroy();
-header('Location: login.php');
+
+// Clear session cookie
+if (ini_get("session.use_cookies")) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000,
+        $params["path"], $params["domain"],
+        $params["secure"], $params["httponly"]
+    );
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>✨ Hasta Pronto - Celestial Chat</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+<style>
+:root {
+    --primary-gold: #D4AF37;
+    --secondary-gold: #FFD700;
+    --deep-blue: #0B1426;
+    --navy-blue: #1A2332;
+    --light-blue: #2C3E50;
+    --accent-blue: #34495E;
+    --text-light: #ECF0F1;
+    --text-muted: #BDC3C7;
+    --shadow-gold: rgba(212, 175, 55, 0.3);
+    --gradient-bg: linear-gradient(135deg, #0B1426 0%, #1A2332 50%, #2C3E50 100%);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: var(--gradient-bg);
+    color: var(--text-light);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+}
+
+/* Animated Background Stars */
+.stars {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.star {
+    position: absolute;
+    background: var(--secondary-gold);
+    border-radius: 50%;
+    animation: twinkle 2s infinite ease-in-out;
+}
+
+.star:nth-child(odd) {
+    animation-delay: 1s;
+}
+
+@keyframes twinkle {
+    0%, 100% { opacity: 0.3; transform: scale(1); }
+    50% { opacity: 1; transform: scale(1.2); }
+}
+
+/* Logout Container */
+.logout-container {
+    position: relative;
+    z-index: 10;
+    width: 100%;
+    max-width: 500px;
+    padding: 2rem;
+    text-align: center;
+}
+
+.logout-card {
+    background: rgba(26, 35, 50, 0.9);
+    backdrop-filter: blur(20px);
+    border: 2px solid var(--primary-gold);
+    border-radius: 20px;
+    padding: 3rem 2rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), 0 0 40px var(--shadow-gold);
+    animation: fadeInScale 0.8s ease-out;
+}
+
+@keyframes fadeInScale {
+    from { 
+        opacity: 0; 
+        transform: scale(0.8); 
+    }
+    to { 
+        opacity: 1; 
+        transform: scale(1); 
+    }
+}
+
+/* Logout Icon */
+.logout-icon {
+    width: 100px;
+    height: 100px;
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2.5rem;
+    color: var(--deep-blue);
+    margin: 0 auto 2rem;
+    position: relative;
+    box-shadow: 0 8px 25px var(--shadow-gold);
+    animation: pulse 2s infinite ease-in-out;
+}
+
+@keyframes pulse {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+}
+
+.logout-icon::after {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    background: linear-gradient(45deg, var(--primary-gold), var(--secondary-gold), var(--primary-gold));
+    border-radius: 50%;
+    z-index: -1;
+    animation: rotate 3s linear infinite;
+}
+
+@keyframes rotate {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* Typography */
+.logout-title {
+    color: var(--secondary-gold);
+    font-size: 2rem;
+    font-weight: 300;
+    letter-spacing: 1px;
+    margin-bottom: 1rem;
+}
+
+.logout-message {
+    color: var(--text-light);
+    font-size: 1.1rem;
+    margin-bottom: 2rem;
+    line-height: 1.6;
+}
+
+.logout-submessage {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    margin-bottom: 2rem;
+    line-height: 1.5;
+}
+
+/* Countdown */
+.countdown-container {
+    background: rgba(52, 73, 94, 0.5);
+    border: 2px solid rgba(212, 175, 55, 0.3);
+    border-radius: 15px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.countdown-text {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+}
+
+.countdown-timer {
+    color: var(--primary-gold);
+    font-size: 2rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.countdown-progress {
+    width: 100%;
+    height: 4px;
+    background: rgba(52, 73, 94, 0.5);
+    border-radius: 2px;
+    margin-top: 1rem;
+    overflow: hidden;
+}
+
+.countdown-progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, var(--primary-gold), var(--secondary-gold));
+    border-radius: 2px;
+    transition: width 1s linear;
+    width: 100%;
+}
+
+/* Action Buttons */
+.action-buttons {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.btn {
+    padding: 1rem 2rem;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none;
+    text-align: center;
+    justify-content: center;
+    min-width: 150px;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    color: var(--deep-blue);
+}
+
+.btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px var(--shadow-gold);
+}
+
+.btn-secondary {
+    background: rgba(52, 73, 94, 0.8);
+    color: var(--text-light);
+    border: 2px solid rgba(212, 175, 55, 0.3);
+}
+
+.btn-secondary:hover {
+    border-color: var(--primary-gold);
+    background: rgba(52, 73, 94, 1);
+    transform: translateY(-2px);
+}
+
+/* Success Animation */
+.success-checkmark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--primary-gold);
+    color: var(--deep-blue);
+    animation: checkmarkPop 0.6s ease-out;
+}
+
+@keyframes checkmarkPop {
+    0% { transform: scale(0); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+/* Floating particles */
+.particle {
+    position: absolute;
+    background: var(--primary-gold);
+    border-radius: 50%;
+    pointer-events: none;
+    animation: floatUp 3s ease-out infinite;
+}
+
+@keyframes floatUp {
+    0% { 
+        opacity: 1; 
+        transform: translateY(0) scale(1); 
+    }
+    100% { 
+        opacity: 0; 
+        transform: translateY(-100px) scale(0.5); 
+    }
+}
+
+/* Responsive Design */
+@media (max-width: 480px) {
+    .logout-container {
+        padding: 1rem;
+    }
+    
+    .logout-card {
+        padding: 2rem 1.5rem;
+    }
+    
+    .logout-title {
+        font-size: 1.6rem;
+    }
+    
+    .countdown-timer {
+        font-size: 1.5rem;
+    }
+    
+    .action-buttons {
+        flex-direction: column;
+    }
+}
+</style>
+</head>
+<body>
+
+<!-- Animated Stars Background -->
+<div class="stars" id="stars"></div>
+
+<!-- Logout Container -->
+<div class="logout-container">
+    <div class="logout-card">
+        
+        <!-- Logout Icon -->
+        <div class="logout-icon">
+            <i class="fas fa-sign-out-alt"></i>
+        </div>
+
+        <!-- Content -->
+        <?php if ($was_logged_in): ?>
+            <h1 class="logout-title">¡Hasta Pronto!</h1>
+            <p class="logout-message">
+                <span class="success-checkmark">
+                    <i class="fas fa-check"></i>
+                </span>
+                Has cerrado sesión exitosamente del Chat Celestial
+            </p>
+            <p class="logout-submessage">
+                Gracias por usar nuestra plataforma. Esperamos verte pronto en las estrellas.
+            </p>
+        <?php else: ?>
+            <h1 class="logout-title">Sesión Finalizada</h1>
+            <p class="logout-message">
+                Tu sesión ha sido cerrada correctamente
+            </p>
+            <p class="logout-submessage">
+                Puedes iniciar sesión nuevamente cuando lo desees.
+            </p>
+        <?php endif; ?>
+
+        <!-- Countdown -->
+        <div class="countdown-container">
+            <div class="countdown-text">Redirigiendo al login en:</div>
+            <div class="countdown-timer">
+                <i class="fas fa-clock"></i>
+                <span id="countdown"><?php echo $redirect_delay; ?></span>
+                <span>segundos</span>
+            </div>
+            <div class="countdown-progress">
+                <div class="countdown-progress-bar" id="progressBar"></div>
+            </div>
+        </div>
+
+        <!-- Action Buttons -->
+        <div class="action-buttons">
+            <a href="login.php" class="btn btn-primary">
+                <i class="fas fa-sign-in-alt"></i>
+                Iniciar Sesión
+            </a>
+            <a href="register.php" class="btn btn-secondary">
+                <i class="fas fa-user-plus"></i>
+                Crear Cuenta
+            </a>
+        </div>
+
+    </div>
+</div>
+
+<script>
+// Create animated stars
+function createStars() {
+    const starsContainer = document.getElementById('stars');
+    const numStars = 60;
+    
+    for (let i = 0; i < numStars; i++) {
+        const star = document.createElement('div');
+        star.className = 'star';
+        star.style.left = Math.random() * 100 + '%';
+        star.style.top = Math.random() * 100 + '%';
+        star.style.width = Math.random() * 3 + 1 + 'px';
+        star.style.height = star.style.width;
+        star.style.animationDelay = Math.random() * 2 + 's';
+        starsContainer.appendChild(star);
+    }
+}
+
+// Countdown functionality
+let timeLeft = <?php echo $redirect_delay; ?>;
+const countdownElement = document.getElementById('countdown');
+const progressBar = document.getElementById('progressBar');
+const totalTime = timeLeft;
+
+function updateCountdown() {
+    countdownElement.textContent = timeLeft;
+    
+    // Update progress bar
+    const percentage = ((totalTime - timeLeft) / totalTime) * 100;
+    progressBar.style.width = percentage + '%';
+    
+    if (timeLeft <= 0) {
+        window.location.href = 'login.php';
+        return;
+    }
+    
+    timeLeft--;
+    setTimeout(updateCountdown, 1000);
+}
+
+// Create floating particles
+function createParticle() {
+    const particle = document.createElement('div');
+    particle.className = 'particle';
+    particle.style.left = Math.random() * 100 + '%';
+    particle.style.bottom = '0';
+    particle.style.width = Math.random() * 4 + 2 + 'px';
+    particle.style.height = particle.style.width;
+    particle.style.animationDelay = Math.random() * 2 + 's';
+    document.body.appendChild(particle);
+    
+    // Remove particle after animation
+    setTimeout(() => particle.remove(), 3000);
+}
+
+// Initialize
+document.addEventListener('DOMContentLoaded', function() {
+    createStars();
+    updateCountdown();
+    
+    // Create particles periodically
+    setInterval(createParticle, 500);
+});
+
+// Add keyboard shortcut for immediate login
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' || e.key === ' ') {
+        window.location.href = 'login.php';
+    }
+});
+
+// Prevent accidental back navigation
+window.addEventListener('beforeunload', function(e) {
+    // Don't show confirmation for logout page
+    return;
+});
+
+// Add subtle floating animation to the card
+let start = Date.now();
+function animateCard() {
+    const card = document.querySelector('.logout-card');
+    const elapsed = Date.now() - start;
+    const y = Math.sin(elapsed / 2000) * 2;
+    card.style.transform = `translateY(${y}px)`;
+    requestAnimationFrame(animateCard);
+}
+animateCard();
+</script>
+
+</body>
+</html>

--- a/openai.php
+++ b/openai.php
@@ -1,0 +1,30 @@
+<?php
+// Simple helper function to query the OpenAI API using curl
+function call_openai_api(array $messages): string {
+    $apiKey = getenv('OPENAI_API_KEY');
+    if (!$apiKey) {
+        return 'Error: OPENAI_API_KEY not set';
+    }
+
+    $data = [
+        'model' => 'gpt-3.5-turbo',
+        'messages' => $messages,
+    ];
+
+    $ch = curl_init('https://api.openai.com/v1/chat/completions');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . $apiKey,
+    ]);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+        return 'Error connecting to OpenAI API';
+    }
+
+    $result = json_decode($response, true);
+    return $result['choices'][0]['message']['content'] ?? 'No response';
+}

--- a/privacy.php
+++ b/privacy.php
@@ -1,0 +1,16 @@
+<?php
+// privacy.php - simple page describing data collection
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Privacidad</title>
+</head>
+<body>
+<h1>Política de privacidad</h1>
+<p>Este chat almacena los mensajes enviados por los usuarios y las respuestas generadas con la API de OpenAI.
+Los datos de perfil se guardan para mantener el historial y personalizar la experiencia.
+Puedes actualizar o eliminar tu información en cualquier momento desde tu <a href="profile.php">perfil</a>.</p>
+</body>
+</html>

--- a/profile.php
+++ b/profile.php
@@ -1,0 +1,66 @@
+<?php
+session_start();
+require 'db.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$usuario_id = $_SESSION['usuario_id'];
+
+// Obtener datos actuales
+$stmt = $pdo->prepare('SELECT nombre, apellido, empresa, email, telefono FROM usuarios WHERE id = ?');
+$stmt->execute([$usuario_id]);
+$usuario = $stmt->fetch();
+
+if (!$usuario) {
+    echo 'Usuario no encontrado';
+    exit;
+}
+
+// Actualizar datos
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
+    $nombre = trim($_POST['nombre']);
+    $apellido = trim($_POST['apellido']);
+    $empresa = trim($_POST['empresa']);
+    $email = trim($_POST['email']);
+    $telefono = trim($_POST['telefono']);
+
+    $stmt = $pdo->prepare('UPDATE usuarios SET nombre = ?, apellido = ?, empresa = ?, email = ?, telefono = ? WHERE id = ?');
+    $stmt->execute([$nombre, $apellido, $empresa, $email, $telefono, $usuario_id]);
+    header('Location: profile.php');
+    exit;
+}
+
+// Eliminar cuenta
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
+    $stmt = $pdo->prepare('DELETE FROM usuarios WHERE id = ?');
+    $stmt->execute([$usuario_id]);
+    session_destroy();
+    header('Location: register.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Perfil</title>
+</head>
+<body>
+<h1>Mi perfil</h1>
+<form method="post">
+    <input name="nombre" value="<?php echo htmlspecialchars($usuario['nombre']); ?>" required><br>
+    <input name="apellido" value="<?php echo htmlspecialchars($usuario['apellido']); ?>" required><br>
+    <input name="empresa" value="<?php echo htmlspecialchars($usuario['empresa']); ?>"><br>
+    <input name="email" type="email" value="<?php echo htmlspecialchars($usuario['email']); ?>" required><br>
+    <input name="telefono" value="<?php echo htmlspecialchars($usuario['telefono']); ?>" required><br>
+    <button type="submit" name="update">Guardar cambios</button>
+</form>
+<form method="post" onsubmit="return confirm('¿Eliminar cuenta definitivamente?')" style="margin-top:1em;">
+    <button type="submit" name="delete">Eliminar mi cuenta</button>
+</form>
+<p><a href="chat.php">Volver al chat</a></p>
+</body>
+</html>

--- a/profile.php
+++ b/profile.php
@@ -19,6 +19,9 @@ if (!$usuario) {
     exit;
 }
 
+$success_message = '';
+$error_message = '';
+
 // Actualizar datos
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
     $nombre = trim($_POST['nombre']);
@@ -27,10 +30,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update'])) {
     $email = trim($_POST['email']);
     $telefono = trim($_POST['telefono']);
 
-    $stmt = $pdo->prepare('UPDATE usuarios SET nombre = ?, apellido = ?, empresa = ?, email = ?, telefono = ? WHERE id = ?');
-    $stmt->execute([$nombre, $apellido, $empresa, $email, $telefono, $usuario_id]);
-    header('Location: profile.php');
-    exit;
+    // Validar email único (excepto el actual)
+    $stmt = $pdo->prepare('SELECT id FROM usuarios WHERE email = ? AND id != ?');
+    $stmt->execute([$email, $usuario_id]);
+    if ($stmt->fetch()) {
+        $error_message = 'Este email ya está en uso por otro usuario.';
+    } else {
+        $stmt = $pdo->prepare('UPDATE usuarios SET nombre = ?, apellido = ?, empresa = ?, email = ?, telefono = ? WHERE id = ?');
+        $stmt->execute([$nombre, $apellido, $empresa, $email, $telefono, $usuario_id]);
+        $success_message = 'Perfil actualizado correctamente.';
+        
+        // Actualizar datos para mostrar
+        $usuario['nombre'] = $nombre;
+        $usuario['apellido'] = $apellido;
+        $usuario['empresa'] = $empresa;
+        $usuario['email'] = $email;
+        $usuario['telefono'] = $telefono;
+    }
 }
 
 // Eliminar cuenta
@@ -46,21 +62,733 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
 <html lang="es">
 <head>
 <meta charset="UTF-8">
-<title>Perfil</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>✨ Mi Perfil Celestial</title>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+<style>
+:root {
+    --primary-gold: #D4AF37;
+    --secondary-gold: #FFD700;
+    --deep-blue: #0B1426;
+    --navy-blue: #1A2332;
+    --light-blue: #2C3E50;
+    --accent-blue: #34495E;
+    --text-light: #ECF0F1;
+    --text-muted: #BDC3C7;
+    --shadow-gold: rgba(212, 175, 55, 0.3);
+    --gradient-bg: linear-gradient(135deg, #0B1426 0%, #1A2332 50%, #2C3E50 100%);
+    --error-red: #E74C3C;
+    --success-green: #27AE60;
+    --warning-orange: #F39C12;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: var(--gradient-bg);
+    color: var(--text-light);
+    min-height: 100vh;
+    padding-bottom: 100px;
+}
+
+/* Animated Background Stars */
+.stars {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.star {
+    position: absolute;
+    background: var(--secondary-gold);
+    border-radius: 50%;
+    animation: twinkle 3s infinite ease-in-out;
+}
+
+.star:nth-child(odd) {
+    animation-delay: 1.5s;
+}
+
+@keyframes twinkle {
+    0%, 100% { opacity: 0.2; transform: scale(1); }
+    50% { opacity: 0.8; transform: scale(1.3); }
+}
+
+/* Header */
+.header {
+    background: rgba(11, 20, 38, 0.9);
+    backdrop-filter: blur(10px);
+    padding: 1.5rem 2rem;
+    border-bottom: 2px solid var(--primary-gold);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    box-shadow: 0 4px 20px var(--shadow-gold);
+}
+
+.header-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.header h1 {
+    color: var(--secondary-gold);
+    font-size: 1.8rem;
+    font-weight: 300;
+    letter-spacing: 2px;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.star-icon {
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.1); opacity: 0.8; }
+}
+
+.back-btn {
+    background: transparent;
+    border: 2px solid var(--primary-gold);
+    color: var(--primary-gold);
+    padding: 0.5rem 1rem;
+    border-radius: 25px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 0.9rem;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.back-btn:hover {
+    background: var(--primary-gold);
+    color: var(--deep-blue);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px var(--shadow-gold);
+}
+
+/* Main Container */
+.main-container {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 2rem;
+    position: relative;
+    z-index: 10;
+}
+
+/* Profile Card */
+.profile-card {
+    background: rgba(26, 35, 50, 0.9);
+    backdrop-filter: blur(20px);
+    border: 2px solid var(--primary-gold);
+    border-radius: 20px;
+    padding: 2rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3), 0 0 40px var(--shadow-gold);
+    animation: slideInUp 0.6s ease-out;
+    margin-bottom: 2rem;
+}
+
+@keyframes slideInUp {
+    from { 
+        opacity: 0; 
+        transform: translateY(50px); 
+    }
+    to { 
+        opacity: 1; 
+        transform: translateY(0); 
+    }
+}
+
+/* Profile Header */
+.profile-header {
+    text-align: center;
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid rgba(212, 175, 55, 0.2);
+}
+
+.profile-avatar {
+    width: 100px;
+    height: 100px;
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2.5rem;
+    color: var(--deep-blue);
+    margin: 0 auto 1rem;
+    position: relative;
+    box-shadow: 0 8px 25px var(--shadow-gold);
+}
+
+.profile-avatar::after {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    background: linear-gradient(45deg, var(--primary-gold), var(--secondary-gold), var(--primary-gold));
+    border-radius: 50%;
+    z-index: -1;
+    animation: rotate 3s linear infinite;
+}
+
+@keyframes rotate {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.profile-name {
+    color: var(--secondary-gold);
+    font-size: 1.5rem;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+}
+
+.profile-email {
+    color: var(--text-muted);
+    font-size: 1rem;
+}
+
+/* Form Styles */
+.profile-form {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.form-group {
+    position: relative;
+}
+
+.form-group.full-width {
+    grid-column: 1 / -1;
+}
+
+.form-label {
+    display: block;
+    color: var(--secondary-gold);
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.form-input {
+    width: 100%;
+    background: rgba(52, 73, 94, 0.5);
+    border: 2px solid rgba(212, 175, 55, 0.3);
+    color: var(--text-light);
+    padding: 1rem;
+    border-radius: 12px;
+    font-size: 1rem;
+    transition: all 0.3s ease;
+    outline: none;
+}
+
+.form-input:focus {
+    border-color: var(--primary-gold);
+    box-shadow: 0 0 15px var(--shadow-gold);
+    background: rgba(52, 73, 94, 0.8);
+    transform: translateY(-2px);
+}
+
+.form-input::placeholder {
+    color: var(--text-muted);
+}
+
+/* Buttons */
+.btn-group {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    margin-top: 2rem;
+}
+
+.btn {
+    padding: 1rem 2rem;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none;
+    text-align: center;
+    justify-content: center;
+    min-width: 150px;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, var(--primary-gold), var(--secondary-gold));
+    color: var(--deep-blue);
+}
+
+.btn-primary:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 25px var(--shadow-gold);
+}
+
+.btn-danger {
+    background: linear-gradient(135deg, var(--error-red), #C0392B);
+    color: white;
+}
+
+.btn-danger:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 25px rgba(231, 76, 60, 0.4);
+}
+
+/* Messages */
+.message {
+    padding: 1rem 1.5rem;
+    border-radius: 12px;
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    animation: slideInDown 0.4s ease-out;
+}
+
+@keyframes slideInDown {
+    from { opacity: 0; transform: translateY(-20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.message.success {
+    background: rgba(39, 174, 96, 0.1);
+    border: 1px solid var(--success-green);
+    color: var(--success-green);
+}
+
+.message.error {
+    background: rgba(231, 76, 60, 0.1);
+    border: 1px solid var(--error-red);
+    color: var(--error-red);
+}
+
+/* Danger Zone */
+.danger-zone {
+    background: rgba(231, 76, 60, 0.05);
+    border: 2px solid rgba(231, 76, 60, 0.3);
+    border-radius: 15px;
+    padding: 1.5rem;
+    margin-top: 2rem;
+}
+
+.danger-zone h3 {
+    color: var(--error-red);
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.danger-zone p {
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+    line-height: 1.6;
+}
+
+/* Modal */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal {
+    background: rgba(26, 35, 50, 0.95);
+    backdrop-filter: blur(20px);
+    border: 2px solid var(--primary-gold);
+    border-radius: 20px;
+    padding: 2rem;
+    max-width: 400px;
+    width: 90%;
+    text-align: center;
+    animation: modalSlide 0.3s ease-out;
+}
+
+@keyframes modalSlide {
+    from { opacity: 0; transform: scale(0.8); }
+    to { opacity: 1; transform: scale(1); }
+}
+
+.modal h3 {
+    color: var(--error-red);
+    margin-bottom: 1rem;
+}
+
+.modal p {
+    color: var(--text-muted);
+    margin-bottom: 1.5rem;
+    line-height: 1.6;
+}
+
+.modal-buttons {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+}
+
+.modal .btn {
+    min-width: 100px;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .header {
+        padding: 1rem;
+    }
+    
+    .header-content {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    .main-container {
+        padding: 0 1rem;
+    }
+    
+    .profile-card {
+        padding: 1.5rem;
+    }
+    
+    .form-row {
+        grid-template-columns: 1fr;
+    }
+    
+    .btn-group {
+        flex-direction: column;
+    }
+    
+    .modal {
+        padding: 1.5rem;
+    }
+    
+    .modal-buttons {
+        flex-direction: column;
+    }
+}
+</style>
 </head>
 <body>
-<h1>Mi perfil</h1>
-<form method="post">
-    <input name="nombre" value="<?php echo htmlspecialchars($usuario['nombre']); ?>" required><br>
-    <input name="apellido" value="<?php echo htmlspecialchars($usuario['apellido']); ?>" required><br>
-    <input name="empresa" value="<?php echo htmlspecialchars($usuario['empresa']); ?>"><br>
-    <input name="email" type="email" value="<?php echo htmlspecialchars($usuario['email']); ?>" required><br>
-    <input name="telefono" value="<?php echo htmlspecialchars($usuario['telefono']); ?>" required><br>
-    <button type="submit" name="update">Guardar cambios</button>
+
+<!-- Animated Stars Background -->
+<div class="stars" id="stars"></div>
+
+<!-- Header -->
+<header class="header">
+    <div class="header-content">
+        <h1>
+            <i class="fas fa-star star-icon"></i>
+            Mi Perfil Celestial
+        </h1>
+        <a href="chat.php" class="back-btn">
+            <i class="fas fa-arrow-left"></i>
+            Volver al Chat
+        </a>
+    </div>
+</header>
+
+<!-- Main Container -->
+<div class="main-container">
+    
+    <!-- Success/Error Messages -->
+    <?php if (!empty($success_message)): ?>
+        <div class="message success">
+            <i class="fas fa-check-circle"></i>
+            <?php echo htmlspecialchars($success_message); ?>
+        </div>
+    <?php endif; ?>
+    
+    <?php if (!empty($error_message)): ?>
+        <div class="message error">
+            <i class="fas fa-exclamation-triangle"></i>
+            <?php echo htmlspecialchars($error_message); ?>
+        </div>
+    <?php endif; ?>
+
+    <!-- Profile Card -->
+    <div class="profile-card">
+        
+        <!-- Profile Header -->
+        <div class="profile-header">
+            <div class="profile-avatar">
+                <i class="fas fa-user"></i>
+            </div>
+            <h2 class="profile-name">
+                <?php echo htmlspecialchars($usuario['nombre'] . ' ' . $usuario['apellido']); ?>
+            </h2>
+            <p class="profile-email">
+                <?php echo htmlspecialchars($usuario['email']); ?>
+            </p>
+        </div>
+
+        <!-- Profile Form -->
+        <form method="post" class="profile-form" id="profileForm">
+            <div class="form-row">
+                <div class="form-group">
+                    <label class="form-label">
+                        <i class="fas fa-user"></i>
+                        Nombre
+                    </label>
+                    <input 
+                        name="nombre" 
+                        class="form-input"
+                        value="<?php echo htmlspecialchars($usuario['nombre']); ?>" 
+                        placeholder="Tu nombre"
+                        required
+                    >
+                </div>
+                
+                <div class="form-group">
+                    <label class="form-label">
+                        <i class="fas fa-user-tag"></i>
+                        Apellido
+                    </label>
+                    <input 
+                        name="apellido" 
+                        class="form-input"
+                        value="<?php echo htmlspecialchars($usuario['apellido']); ?>" 
+                        placeholder="Tu apellido"
+                        required
+                    >
+                </div>
+            </div>
+
+            <div class="form-group full-width">
+                <label class="form-label">
+                    <i class="fas fa-building"></i>
+                    Empresa
+                </label>
+                <input 
+                    name="empresa" 
+                    class="form-input"
+                    value="<?php echo htmlspecialchars($usuario['empresa']); ?>" 
+                    placeholder="Tu empresa (opcional)"
+                >
+            </div>
+
+            <div class="form-group full-width">
+                <label class="form-label">
+                    <i class="fas fa-envelope"></i>
+                    Email
+                </label>
+                <input 
+                    name="email" 
+                    type="email" 
+                    class="form-input"
+                    value="<?php echo htmlspecialchars($usuario['email']); ?>" 
+                    placeholder="tu@email.com"
+                    required
+                >
+            </div>
+
+            <div class="form-group full-width">
+                <label class="form-label">
+                    <i class="fas fa-phone"></i>
+                    Teléfono
+                </label>
+                <input 
+                    name="telefono" 
+                    class="form-input"
+                    value="<?php echo htmlspecialchars($usuario['telefono']); ?>" 
+                    placeholder="Tu número de teléfono"
+                    required
+                >
+            </div>
+
+            <div class="btn-group">
+                <button type="submit" name="update" class="btn btn-primary">
+                    <i class="fas fa-save"></i>
+                    Guardar Cambios
+                </button>
+            </div>
+        </form>
+
+    </div>
+
+    <!-- Danger Zone -->
+    <div class="danger-zone">
+        <h3>
+            <i class="fas fa-exclamation-triangle"></i>
+            Zona de Peligro
+        </h3>
+        <p>
+            Una vez que elimines tu cuenta, no hay vuelta atrás. Por favor, asegúrate de que realmente quieres hacer esto.
+        </p>
+        <button class="btn btn-danger" onclick="showDeleteModal()">
+            <i class="fas fa-trash"></i>
+            Eliminar Mi Cuenta
+        </button>
+    </div>
+
+</div>
+
+<!-- Delete Confirmation Modal -->
+<div class="modal-overlay" id="deleteModal">
+    <div class="modal">
+        <h3>
+            <i class="fas fa-exclamation-triangle"></i>
+            ¿Eliminar Cuenta?
+        </h3>
+        <p>
+            Esta acción es <strong>irreversible</strong>. Se eliminarán todos tus datos, conversaciones y configuraciones.
+        </p>
+        <div class="modal-buttons">
+            <button class="btn btn-danger" onclick="confirmDelete()">
+                <i class="fas fa-trash"></i>
+                Sí, Eliminar
+            </button>
+            <button class="btn btn-primary" onclick="hideDeleteModal()">
+                <i class="fas fa-times"></i>
+                Cancelar
+            </button>
+        </div>
+    </div>
+</div>
+
+<!-- Hidden delete form -->
+<form method="post" id="deleteForm" style="display: none;">
+    <input type="hidden" name="delete" value="1">
 </form>
-<form method="post" onsubmit="return confirm('¿Eliminar cuenta definitivamente?')" style="margin-top:1em;">
-    <button type="submit" name="delete">Eliminar mi cuenta</button>
-</form>
-<p><a href="chat.php">Volver al chat</a></p>
+
+<script>
+// Create animated stars
+function createStars() {
+    const starsContainer = document.getElementById('stars');
+    const numStars = 40;
+    
+    for (let i = 0; i < numStars; i++) {
+        const star = document.createElement('div');
+        star.className = 'star';
+        star.style.left = Math.random() * 100 + '%';
+        star.style.top = Math.random() * 100 + '%';
+        star.style.width = Math.random() * 3 + 1 + 'px';
+        star.style.height = star.style.width;
+        star.style.animationDelay = Math.random() * 3 + 's';
+        starsContainer.appendChild(star);
+    }
+}
+
+// Delete Modal Functions
+function showDeleteModal() {
+    document.getElementById('deleteModal').style.display = 'flex';
+    document.body.style.overflow = 'hidden';
+}
+
+function hideDeleteModal() {
+    document.getElementById('deleteModal').style.display = 'none';
+    document.body.style.overflow = 'auto';
+}
+
+function confirmDelete() {
+    document.getElementById('deleteForm').submit();
+}
+
+// Close modal on overlay click
+document.getElementById('deleteModal').addEventListener('click', function(e) {
+    if (e.target === this) {
+        hideDeleteModal();
+    }
+});
+
+// Form validation and enhancement
+document.getElementById('profileForm').addEventListener('submit', function(e) {
+    const submitBtn = this.querySelector('button[type="submit"]');
+    const btnIcon = submitBtn.querySelector('i');
+    const btnText = submitBtn.lastChild;
+    
+    // Add loading state
+    submitBtn.disabled = true;
+    btnIcon.className = 'fas fa-spinner fa-spin';
+    btnText.textContent = ' Guardando...';
+    
+    // Re-enable after a delay (in case of validation errors)
+    setTimeout(() => {
+        submitBtn.disabled = false;
+        btnIcon.className = 'fas fa-save';
+        btnText.textContent = ' Guardar Cambios';
+    }, 3000);
+});
+
+// Auto-hide success messages
+setTimeout(() => {
+    const successMessage = document.querySelector('.message.success');
+    if (successMessage) {
+        successMessage.style.opacity = '0';
+        successMessage.style.transform = 'translateY(-20px)';
+        setTimeout(() => successMessage.remove(), 300);
+    }
+}, 5000);
+
+// Initialize
+document.addEventListener('DOMContentLoaded', function() {
+    createStars();
+    
+    // Focus on first input
+    document.querySelector('.form-input').focus();
+});
+
+// Add floating animation to profile avatar
+let start = Date.now();
+function animateAvatar() {
+    const avatar = document.querySelector('.profile-avatar');
+    const elapsed = Date.now() - start;
+    const y = Math.sin(elapsed / 2000) * 2;
+    avatar.style.transform = `translateY(${y}px)`;
+    requestAnimationFrame(animateAvatar);
+}
+animateAvatar();
+
+// Keyboard shortcuts
+document.addEventListener('keydown', function(e) {
+    // Ctrl+S to save
+    if (e.ctrlKey && e.key === 's') {
+        e.preventDefault();
+        document.getElementById('profileForm').submit();
+    }
+    
+    // Escape to close modal
+    if (e.key === 'Escape') {
+        hideDeleteModal();
+    }
+});
+</script>
+
 </body>
 </html>

--- a/prompts.php
+++ b/prompts.php
@@ -1,0 +1,29 @@
+<?php
+// prompts.php - Define prompt sets for OpenAI initialization.
+// Each set is keyed by a name and contains an array of messages.
+$promptSets = [
+    'default' => [
+        [
+            'role' => 'system',
+            'content' => 'Eres un asistente que realiza una encuesta de forma amena para comprender el negocio del usuario. Informa que las respuestas se guardan y que se utiliza la API de OpenAI.'
+        ],
+        [
+            'role' => 'assistant',
+            'content' => '¡Hola! Antes de empezar, puedes indicarme tu nombre o cómo prefieres que te llame?'
+        ],
+        [
+            'role' => 'assistant',
+            'content' => '¿Cuál es el objetivo principal de tu negocio o proyecto?'
+        ],
+        [
+            'role' => 'assistant',
+            'content' => '¿Tienes alguna preferencia de estilo o colores para la imagen de tu marca?'
+        ],
+    ],
+];
+
+if (php_sapi_name() === 'cli' && basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
+    print_r($promptSets);
+}
+
+return $promptSets;

--- a/register.php
+++ b/register.php
@@ -1,0 +1,46 @@
+<?php
+require 'db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $nombre   = trim($_POST['nombre']);
+    $apellido = trim($_POST['apellido']);
+    $empresa  = trim($_POST['empresa']);
+    $email    = trim($_POST['email']);
+    $telefono = trim($_POST['telefono']);
+    $password = $_POST['password'];
+
+    $stmt = $pdo->prepare("SELECT id FROM usuarios WHERE email = ? OR telefono = ? LIMIT 1");
+    $stmt->execute([$email, $telefono]);
+    if ($stmt->fetch()) {
+        $error = 'Ya existe un usuario con ese email o teléfono.';
+    } else {
+        $hash = password_hash($password, PASSWORD_BCRYPT);
+        $defaultPrompt = $pdo->query("SELECT id FROM prompt_sets ORDER BY id LIMIT 1")->fetchColumn();
+        $stmt = $pdo->prepare("INSERT INTO usuarios (nombre, apellido, empresa, email, telefono, password, prompt_set_id, es_admin) VALUES (?, ?, ?, ?, ?, ?, ?, 0)");
+        $stmt->execute([$nombre, $apellido, $empresa, $email, $telefono, $hash, $defaultPrompt]);
+        header('Location: login.php');
+        exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Registro</title>
+</head>
+<body>
+<h1>Registro</h1>
+<form method="post">
+    <input name="nombre" placeholder="Nombre" required><br>
+    <input name="apellido" placeholder="Apellido" required><br>
+    <input name="empresa" placeholder="Empresa"><br>
+    <input name="email" type="email" placeholder="Email" required><br>
+    <input name="telefono" placeholder="Teléfono" required><br>
+    <input name="password" type="password" placeholder="Contraseña" required><br>
+    <button type="submit">Registrar</button>
+</form>
+<p style="font-size:small">Al registrarte aceptas la <a href="privacy.php">política de privacidad</a> y que tus datos sean almacenados.</p>
+<?php if (!empty($error)) echo "<p>$error</p>"; ?>
+</body>
+</html>

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,94 @@
+-- Database schema for the chat application
+-- Ensure you are using the marhar345_merlin database
+
+USE marhar345_merlin;
+
+-- Table of users
+CREATE TABLE IF NOT EXISTS usuarios (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre       VARCHAR(100) NOT NULL,
+    apellido     VARCHAR(100) NOT NULL,
+    empresa      VARCHAR(255),
+    email        VARCHAR(255) NOT NULL UNIQUE,
+    telefono     VARCHAR(50) UNIQUE,
+    password     VARCHAR(255) NOT NULL,
+    foto         VARCHAR(255),
+    es_admin     TINYINT(1) DEFAULT 0,
+    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Design preferences
+CREATE TABLE IF NOT EXISTS preferencias_disenio (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    tema ENUM('light','dark') DEFAULT 'light',
+    color_preferido VARCHAR(50),
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+-- Conversations
+CREATE TABLE IF NOT EXISTS conversaciones (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    fecha_inicio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+-- Messages
+CREATE TABLE IF NOT EXISTS mensajes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    conversacion_id INT NOT NULL,
+    emisor ENUM('usuario','asistente') NOT NULL,
+    texto TEXT NOT NULL,
+    fecha_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (conversacion_id) REFERENCES conversaciones(id) ON DELETE CASCADE
+);
+
+-- Admin defined questions
+CREATE TABLE IF NOT EXISTS preguntas_admin (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    texto_pregunta TEXT NOT NULL,
+    orden INT DEFAULT 0
+);
+
+-- User answers to admin questions
+CREATE TABLE IF NOT EXISTS respuestas (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    pregunta_id INT NOT NULL,
+    respuesta TEXT,
+    fecha_respuesta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
+    FOREIGN KEY (pregunta_id) REFERENCES preguntas_admin(id) ON DELETE CASCADE
+);
+
+-- Optional analysis results
+CREATE TABLE IF NOT EXISTS resultados_analisis (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario_id INT NOT NULL,
+    analisis TEXT,
+    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+);
+
+-- Prompt sets to allow different base instructions
+CREATE TABLE IF NOT EXISTS prompt_sets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL
+);
+
+-- Messages belonging to each prompt set
+CREATE TABLE IF NOT EXISTS prompt_lines (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    set_id INT NOT NULL,
+    role ENUM('system','assistant','user') NOT NULL,
+    content TEXT NOT NULL,
+    orden INT DEFAULT 0,
+    FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE
+);
+
+ALTER TABLE usuarios
+    ADD COLUMN IF NOT EXISTS prompt_set_id INT DEFAULT NULL,
+    ADD CONSTRAINT fk_prompt_set
+        FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id);


### PR DESCRIPTION
## Summary
- let admins assign different prompt sets to each user
- store prompt sets in new tables via `init_prompts.php`
- save default prompt when registering
- update chat to pull base messages from the user's prompt set
- document how to load and manage prompt sets

## Testing
- `php -l prompts.php`
- `php -l init_prompts.php`
- `php -l chat.php`
- `for f in *.php; do php -l $f; done`


------
https://chatgpt.com/codex/tasks/task_e_688a25cab4d883258c90449ca429a6f7