### PR TITLE
refactor: update schema for mysql 8

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -5,6 +5,22 @@ CREATE DATABASE IF NOT EXISTS marhar345_merlin
   CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 USE marhar345_merlin;
 
+-- Prompt sets to allow different base instructions
+CREATE TABLE IF NOT EXISTS prompt_sets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Messages belonging to each prompt set
+CREATE TABLE IF NOT EXISTS prompt_lines (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    set_id INT NOT NULL,
+    role ENUM('system','assistant','user') NOT NULL,
+    content TEXT NOT NULL,
+    orden INT DEFAULT 0,
+    FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- Table of users
 CREATE TABLE IF NOT EXISTS usuarios (
     id INT AUTO_INCREMENT PRIMARY KEY,
@@ -16,7 +32,9 @@ CREATE TABLE IF NOT EXISTS usuarios (
     password     VARCHAR(255) NOT NULL,
     foto         VARCHAR(255),
     es_admin     TINYINT(1) DEFAULT 0,
-    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    prompt_set_id INT DEFAULT NULL,
+    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Design preferences
@@ -74,23 +92,3 @@ CREATE TABLE IF NOT EXISTS resultados_analisis (
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Prompt sets to allow different base instructions
-CREATE TABLE IF NOT EXISTS prompt_sets (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    nombre VARCHAR(100) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Messages belonging to each prompt set
-CREATE TABLE IF NOT EXISTS prompt_lines (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    set_id INT NOT NULL,
-    role ENUM('system','assistant','user') NOT NULL,
-    content TEXT NOT NULL,
-    orden INT DEFAULT 0,
-    FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-ALTER TABLE usuarios
-    ADD COLUMN prompt_set_id INT DEFAULT NULL,
-    ADD CONSTRAINT fk_prompt_set
-        FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id);

--- a/schema.sql
+++ b/schema.sql
@@ -1,6 +1,8 @@
 -- Database schema for the chat application
 -- Ensure you are using the marhar345_merlin database
 
+CREATE DATABASE IF NOT EXISTS marhar345_merlin
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 USE marhar345_merlin;
 
 -- Table of users
@@ -15,7 +17,7 @@ CREATE TABLE IF NOT EXISTS usuarios (
     foto         VARCHAR(255),
     es_admin     TINYINT(1) DEFAULT 0,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Design preferences
 CREATE TABLE IF NOT EXISTS preferencias_disenio (
@@ -24,7 +26,7 @@ CREATE TABLE IF NOT EXISTS preferencias_disenio (
     tema ENUM('light','dark') DEFAULT 'light',
     color_preferido VARCHAR(50),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Conversations
 CREATE TABLE IF NOT EXISTS conversaciones (
@@ -33,7 +35,7 @@ CREATE TABLE IF NOT EXISTS conversaciones (
     fecha_inicio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Messages
 CREATE TABLE IF NOT EXISTS mensajes (
@@ -43,14 +45,14 @@ CREATE TABLE IF NOT EXISTS mensajes (
     texto TEXT NOT NULL,
     fecha_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (conversacion_id) REFERENCES conversaciones(id) ON DELETE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Admin defined questions
 CREATE TABLE IF NOT EXISTS preguntas_admin (
     id INT AUTO_INCREMENT PRIMARY KEY,
     texto_pregunta TEXT NOT NULL,
     orden INT DEFAULT 0
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- User answers to admin questions
 CREATE TABLE IF NOT EXISTS respuestas (
@@ -61,7 +63,7 @@ CREATE TABLE IF NOT EXISTS respuestas (
     fecha_respuesta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
     FOREIGN KEY (pregunta_id) REFERENCES preguntas_admin(id) ON DELETE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Optional analysis results
 CREATE TABLE IF NOT EXISTS resultados_analisis (
@@ -70,13 +72,13 @@ CREATE TABLE IF NOT EXISTS resultados_analisis (
     analisis TEXT,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Prompt sets to allow different base instructions
 CREATE TABLE IF NOT EXISTS prompt_sets (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nombre VARCHAR(100) NOT NULL
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Messages belonging to each prompt set
 CREATE TABLE IF NOT EXISTS prompt_lines (
@@ -86,7 +88,7 @@ CREATE TABLE IF NOT EXISTS prompt_lines (
     content TEXT NOT NULL,
     orden INT DEFAULT 0,
     FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 ALTER TABLE usuarios
     ADD COLUMN IF NOT EXISTS prompt_set_id INT DEFAULT NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -91,6 +91,6 @@ CREATE TABLE IF NOT EXISTS prompt_lines (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 ALTER TABLE usuarios
-    ADD COLUMN IF NOT EXISTS prompt_set_id INT DEFAULT NULL,
+    ADD COLUMN prompt_set_id INT DEFAULT NULL,
     ADD CONSTRAINT fk_prompt_set
         FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id);


### PR DESCRIPTION
## Summary
- ensure schema uses utf8mb4 and InnoDB
- create database if missing
- specify MySQL 8 column addition for prompt sets

## Testing
- `mysql --version` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688a9c56ce34832584b3f0ecfbe7992e