### PR TITLE
feat: store onboarding summary

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -138,6 +138,17 @@ if (isset($_POST['mensaje']) && trim($_POST['mensaje']) !== '') {
 
     $stmt = $pdo->prepare("INSERT INTO mensajes (conversacion_id, emisor, texto) VALUES (?, 'asistente', ?)");
     $stmt->execute([$conver_id, $respuesta]);
+
+    // Cuando el asistente finaliza el onboarding con <<FIN_INFO>>, extraemos el JSON
+    // y lo almacenamos para que el marketer pueda consultarlo posteriormente.
+    if (preg_match('/<<FIN_INFO>>(.*)$/s', $respuesta, $coincidencias)) {
+        $jsonString = trim($coincidencias[1]);
+        $decoded = json_decode($jsonString, true);
+        if (json_last_error() === JSON_ERROR_NONE) {
+            $save = $pdo->prepare('INSERT INTO resultados_analisis (usuario_id, analisis) VALUES (?, ?)');
+            $save->execute([$usuario_id, $jsonString]);
+        }
+    }
 }
 
 // Obtener mensajes para mostrar

--- a/onboarding_prompt.sql
+++ b/onboarding_prompt.sql
@@ -1,13 +1,15 @@
-<?php
-// prompts.php - Define prompt sets for OpenAI initialization.
-// Each set is keyed by a name and contains an array of messages.
-$promptSets = [
-    'default' => [
-        [
-            'role' => 'system',
-            'content' => <<<'PROMPT'
-Eres COMPAÑERO DE ONBOARDING DE MARCA, un interlocutor cálido, empático y perspicaz.
-Tu misión: extraer, a través de una conversación fluida (nunca como cuestionario), toda la información que un marketer-diseñador necesita para crear un manual de marca y diseñar el logo.
+-- Seed data for brand onboarding prompt
+-- Run this after creating tables to populate the default prompt set
+
+USE marhar345_merlin;
+
+INSERT INTO prompt_sets (nombre) VALUES ('default');
+SET @set_id = LAST_INSERT_ID();
+
+INSERT INTO prompt_lines (set_id, role, content, orden) VALUES
+(@set_id, 'system', 'Eres COMPAÑERO DE ONBOARDING DE MARCA, un interlocutor cálido, empático y perspicaz.
+Tu misión: extraer, a través de una conversación fluida (nunca como cuestionario), toda la información que un marketer-diseñador
+ necesita para crear un manual de marca y diseñar el logo.
 
 ────────────────────────────────────────────────────────
 ### 0 · REGLAS PRINCIPALES
@@ -83,18 +85,6 @@ Si el usuario pide consejos de branding antes de terminar el onboarding, respond
 No aceptes debates políticos, médicos ni otros que no estén ligados al objetivo; redirígelos con cortesía.
 
 ¡Listo! Conversa, captura y resume.
-────────────────────────────────────────────────────────
-PROMPT
-        ],
-        [
-            'role' => 'assistant',
-            'content' => '¡Hola! ¿Qué chispa encendió tu proyecto?'
-        ],
-    ],
-];
+────────────────────────────────────────────────────────', 1),
+(@set_id, 'assistant', '¡Hola! ¿Qué chispa encendió tu proyecto?', 2);
 
-if (php_sapi_name() === 'cli' && basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
-    print_r($promptSets);
-}
-
-return $promptSets;


### PR DESCRIPTION
## Summary
- add SQL seed script to insert brand onboarding prompt set and greeting
- capture <<FIN_INFO>> summaries and save JSON to resultados_analisis
- select database before seeding default prompt set to avoid `#1046` errors

## Testing
- `php -l chat.php`
- `php -l prompts.php`
- `php -l init_prompts.php`
- `php init_prompts.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688acbccfbdc832591f51bf0dd1a739a