### PR TITLE
Personalize chat greeting and preload user profile

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -42,14 +42,9 @@ CREATE TABLE IF NOT EXISTS usuarios (
     password     VARCHAR(255) NOT NULL,
     foto         VARCHAR(255),
     es_admin     TINYINT(1) DEFAULT 0,
-<<<<<<< HEAD
-    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-=======
     prompt_set_id INT DEFAULT NULL,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id)
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Design preferences
@@ -59,10 +54,6 @@ CREATE TABLE IF NOT EXISTS preferencias_disenio (
     tema ENUM('light','dark') DEFAULT 'light',
     color_preferido VARCHAR(50),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Conversations
@@ -72,10 +63,6 @@ CREATE TABLE IF NOT EXISTS conversaciones (
     fecha_inicio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Messages
@@ -86,10 +73,6 @@ CREATE TABLE IF NOT EXISTS mensajes (
     texto TEXT NOT NULL,
     fecha_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (conversacion_id) REFERENCES conversaciones(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Admin defined questions
@@ -97,10 +80,6 @@ CREATE TABLE IF NOT EXISTS preguntas_admin (
     id INT AUTO_INCREMENT PRIMARY KEY,
     texto_pregunta TEXT NOT NULL,
     orden INT DEFAULT 0
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- User answers to admin questions
@@ -112,10 +91,6 @@ CREATE TABLE IF NOT EXISTS respuestas (
     fecha_respuesta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
     FOREIGN KEY (pregunta_id) REFERENCES preguntas_admin(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Optional analysis results
@@ -125,26 +100,6 @@ CREATE TABLE IF NOT EXISTS resultados_analisis (
     analisis TEXT,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Prompt sets to allow different base instructions
-CREATE TABLE IF NOT EXISTS prompt_sets (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    nombre VARCHAR(100) NOT NULL
-);
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Messages belonging to each prompt set
-CREATE TABLE IF NOT EXISTS prompt_lines (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    set_id INT NOT NULL,
-    role ENUM('system','assistant','user') NOT NULL,
-    content TEXT NOT NULL,
-    orden INT DEFAULT 0,
-    FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE
-);
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Password reset tokens for recovery process
@@ -153,14 +108,4 @@ CREATE TABLE IF NOT EXISTS password_resets (
     token VARCHAR(64) NOT NULL,
     expires_at DATETIME NOT NULL,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-);
-
-ALTER TABLE usuarios
-    ADD COLUMN IF NOT EXISTS prompt_set_id INT DEFAULT NULL,
-    ADD COLUMN prompt_set_id INT DEFAULT NULL,
-    ADD CONSTRAINT fk_prompt_set
-        FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id);
-=======
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query

--- a/schema.sql
+++ b/schema.sql
@@ -5,6 +5,16 @@ CREATE DATABASE IF NOT EXISTS marhar345_merlin
   CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 USE marhar345_merlin;
 
+-- System messages
+CREATE TABLE IF NOT EXISTS mensajes_sistema (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    clave VARCHAR(50) UNIQUE NOT NULL,
+    contenido TEXT NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO mensajes_sistema (clave, contenido) VALUES
+('bienvenida', 'Hola {nombre}{empresa_parte} En vez de enviarte un formulario duro para que completes y sepamos más de tu negocio, tus preferencias, ambiciones y necesidades, lo haremos a través de una conversación. Voy a hacerte preguntas de forma natural para que podamos conversar. Es posible que algunas charlas no tengan mucho sentido para vos, pero te aseguro que para mí sí lo tendrán y, si conversás conmigo de manera sincera y fluida, el resultado será más rápido y mejor de lo que esperás.');
+
 -- Prompt sets to allow different base instructions
 CREATE TABLE IF NOT EXISTS prompt_sets (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/schema.sql
+++ b/schema.sql
@@ -12,8 +12,6 @@ CREATE TABLE IF NOT EXISTS mensajes_sistema (
     contenido TEXT NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-INSERT INTO mensajes_sistema (clave, contenido) VALUES
-('bienvenida', 'Hola {nombre}{empresa_parte} En vez de enviarte un formulario duro para que completes y sepamos más de tu negocio, tus preferencias, ambiciones y necesidades, lo haremos a través de una conversación. Voy a hacerte preguntas de forma natural para que podamos conversar. Es posible que algunas charlas no tengan mucho sentido para vos, pero te aseguro que para mí sí lo tendrán y, si conversás conmigo de manera sincera y fluida, el resultado será más rápido y mejor de lo que esperás.');
 
 -- Prompt sets to allow different base instructions
 CREATE TABLE IF NOT EXISTS prompt_sets (


### PR DESCRIPTION
## Summary
- Load full user profile and previous answers when chat opens
- Auto-generate first assistant message greeting the user by name and explaining the chat
- Include profile and answer data as system context for OpenAI responses
- Store welcome message template in the database for easy updates

## Testing
- `php -l chat.php`


------
https://chatgpt.com/codex/tasks/task_e_688ad753da288325ab2ac7dedb6aa7f2