### PR TITLE
fix: save prompt set changes

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -26,9 +26,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmt = $pdo->prepare('UPDATE preguntas_admin SET texto_pregunta = ? WHERE id = ?');
         $stmt->execute([$_POST['edit_text'], $_POST['edit_id']]);
     }
-    if (isset($_POST['prompt_update'])) {
+    if (isset($_POST['user_id'], $_POST['prompt_set_id'])) {
         $stmt = $pdo->prepare('UPDATE usuarios SET prompt_set_id = ? WHERE id = ?');
-        $stmt->execute([$_POST['prompt_set_id'], $_POST['user_id']]);
+        $stmt->execute([(int)$_POST['prompt_set_id'], (int)$_POST['user_id']]);
     }
 
     // prompt set operations


### PR DESCRIPTION
## Summary
- ensure admin updates to user prompt set are applied

## Testing
- `php -l admin.php`


------
https://chatgpt.com/codex/tasks/task_e_688ae67ca5c4832592b48a6e60847248