### PR TITLE
Refactor chat for brand discovery

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -711,5 +711,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
+<?php include 'branch.php'; ?>
+
 </body>
 </html>

--- a/branch.php
+++ b/branch.php
@@ -1,0 +1,28 @@
+<?php
+function current_branch(): string {
+    $headFile = __DIR__ . '/.git/HEAD';
+    if (is_readable($headFile)) {
+        $head = trim(file_get_contents($headFile));
+        if (strpos($head, 'ref:') === 0) {
+            return basename($head);
+        }
+        return $head ?: 'unknown';
+    }
+    return 'unknown';
+}
+$branch = htmlspecialchars(current_branch(), ENT_QUOTES, 'UTF-8');
+?>
+<div id="branch-info">Branch: <?php echo $branch; ?></div>
+<style>
+#branch-info {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    padding: 4px 8px;
+    font-size: 12px;
+    font-family: sans-serif;
+    z-index: 1000;
+}
+</style>

--- a/chat.php
+++ b/chat.php
@@ -2,6 +2,7 @@
 session_start();
 require 'db.php';
 require 'openai.php';
+require 'chat_helpers.php';
 
 if (!isset($_SESSION['usuario_id'])) {
     header('Location: login.php');
@@ -9,24 +10,6 @@ if (!isset($_SESSION['usuario_id'])) {
 }
 
 $usuario_id = $_SESSION['usuario_id'];
-
-// Obtener preferencias de diseño o crear valores por defecto
-$stmt = $pdo->prepare("SELECT tema, color_preferido FROM preferencias_disenio WHERE usuario_id = ? LIMIT 1");
-$stmt->execute([$usuario_id]);
-$pref = $stmt->fetch();
-if (!$pref) {
-    $pref = ['tema' => 'dark', 'color_preferido' => '#D4AF37'];
-    $stmt = $pdo->prepare("INSERT INTO preferencias_disenio (usuario_id, tema, color_preferido) VALUES (?, ?, ?)");
-    $stmt->execute([$usuario_id, $pref['tema'], $pref['color_preferido']]);
-}
-
-// Actualizar preferencias si se envían por formulario
-if (isset($_POST['tema']) && isset($_POST['color'])) {
-    $pref['tema'] = $_POST['tema'];
-    $pref['color_preferido'] = $_POST['color'];
-    $stmt = $pdo->prepare("UPDATE preferencias_disenio SET tema = ?, color_preferido = ? WHERE usuario_id = ?");
-    $stmt->execute([$pref['tema'], $pref['color_preferido'], $usuario_id]);
-}
 
 // Buscar o crear conversación
 $stmt = $pdo->prepare("SELECT id FROM conversaciones WHERE usuario_id = ? LIMIT 1");
@@ -53,61 +36,28 @@ if (isset($_GET['del_msg'])) {
     exit;
 }
 
+// Finalizar y generar informe
+if (isset($_POST['finalizar'])) {
+    $stmt = $pdo->prepare("SELECT emisor, texto FROM mensajes WHERE conversacion_id = ? ORDER BY id");
+    $stmt->execute([$conver_id]);
+    $historial = $stmt->fetchAll();
+    $messages = build_base_messages($pdo, $usuario_id);
+    foreach ($historial as $m) {
+        $messages[] = ['role' => $m['emisor'] === 'usuario' ? 'user' : 'assistant', 'content' => $m['texto']];
+    }
+    $messages[] = ['role' => 'system', 'content' => 'Genera un informe estructurado con toda la información recopilada listo para un diseñador o marketer.'];
+    $analysis = call_openai_api($messages);
+    $stmt = $pdo->prepare("INSERT INTO resultados_analisis (usuario_id, analisis) VALUES (?, ?) ON DUPLICATE KEY UPDATE analisis = VALUES(analisis), fecha_registro = CURRENT_TIMESTAMP");
+    $stmt->execute([$usuario_id, $analysis]);
+    header('Location: summary.php');
+    exit;
+}
+
 // Enviar mensaje
 if (isset($_POST['mensaje']) && trim($_POST['mensaje']) !== '') {
     $mensaje = trim($_POST['mensaje']);
     $stmt = $pdo->prepare("INSERT INTO mensajes (conversacion_id, emisor, texto) VALUES (?, 'usuario', ?)");
     $stmt->execute([$conver_id, $mensaje]);
-
-    // Detectar preferencias de color o tema en el mensaje
-    $mensajeLower = strtolower($mensaje);
-    $colorMap = [
-        'rojo' => '#ff0000',
-        'red' => '#ff0000',
-        'verde' => '#008000',
-        'green' => '#008000',
-        'azul' => '#0000ff',
-        'blue' => '#0000ff',
-        'amarillo' => '#ffff00',
-        'yellow' => '#ffff00',
-        'naranja' => '#ffa500',
-        'orange' => '#ffa500',
-        'violeta' => '#800080',
-        'morado' => '#800080',
-        'purple' => '#800080',
-        'negro' => '#000000',
-        'black' => '#000000',
-        'blanco' => '#ffffff',
-        'white' => '#ffffff',
-        'gris' => '#808080',
-        'gray' => '#808080',
-        'grey' => '#808080',
-        'rosa' => '#ff69b4',
-        'pink' => '#ff69b4',
-        'dorado' => '#D4AF37',
-        'gold' => '#D4AF37'
-    ];
-    $newColor = null;
-    if (preg_match('/#([0-9a-f]{3,6})/i', $mensajeLower, $m)) {
-        $newColor = '#' . $m[1];
-    } elseif (isset($colorMap[$mensajeLower])) {
-        $newColor = $colorMap[$mensajeLower];
-    }
-    if ($newColor) {
-        $pref['color_preferido'] = $newColor;
-        $stmt = $pdo->prepare('UPDATE preferencias_disenio SET color_preferido = ? WHERE usuario_id = ?');
-        $stmt->execute([$newColor, $usuario_id]);
-    }
-    if (strpos($mensajeLower, 'oscuro') !== false || strpos($mensajeLower, 'dark') !== false) {
-        $pref['tema'] = 'dark';
-        $stmt = $pdo->prepare('UPDATE preferencias_disenio SET tema = ? WHERE usuario_id = ?');
-        $stmt->execute(['dark', $usuario_id]);
-    }
-    if (strpos($mensajeLower, 'claro') !== false || strpos($mensajeLower, 'light') !== false) {
-        $pref['tema'] = 'light';
-        $stmt = $pdo->prepare('UPDATE preferencias_disenio SET tema = ? WHERE usuario_id = ?');
-        $stmt->execute(['light', $usuario_id]);
-    }
 
     // Construir historial para la API
     $stmt = $pdo->prepare("SELECT emisor, texto FROM mensajes WHERE conversacion_id = ? ORDER BY id");
@@ -120,22 +70,11 @@ if (isset($_POST['mensaje']) && trim($_POST['mensaje']) !== '') {
 
     // Prompt inicial y preguntas base si es el primer mensaje
     if (count($messages) === 1) {
-        $setStmt = $pdo->prepare('SELECT prompt_set_id FROM usuarios WHERE id = ?');
-        $setStmt->execute([$usuario_id]);
-        $setId = $setStmt->fetchColumn();
-        if ($setId) {
-            $pstmt = $pdo->prepare('SELECT role, content FROM prompt_lines WHERE set_id = ? ORDER BY orden');
-            $pstmt->execute([$setId]);
-            $basePrompts = [];
-            foreach ($pstmt->fetchAll() as $p) {
-                $basePrompts[] = ['role' => $p['role'], 'content' => $p['content']];
-            }
-            $messages = array_merge($basePrompts, $messages);
-        }
+        $base = build_base_messages($pdo, $usuario_id);
+        $messages = array_merge($base, $messages);
     }
 
     $respuesta = call_openai_api($messages);
-
     $stmt = $pdo->prepare("INSERT INTO mensajes (conversacion_id, emisor, texto) VALUES (?, 'asistente', ?)");
     $stmt->execute([$conver_id, $respuesta]);
 }
@@ -146,59 +85,21 @@ $stmt->execute([$conver_id]);
 $mensajes = $stmt->fetchAll();
 ?>
 <!DOCTYPE html>
-<html lang="es" class="<?php echo htmlspecialchars($pref['tema']); ?>">
+<html lang="es">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>✨ Celestial Chat</title>
+<title>Chat de Marca</title>
 <link rel="stylesheet" href="assets/css/chat.css">
-<style>
-:root { --user-color: <?php echo htmlspecialchars($pref['color_preferido']); ?>; }
-</style>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 </head>
-<body class="<?php echo htmlspecialchars($pref['tema']); ?>">
-
-<!-- Header -->
-<header class="header">
-    <h1>
-        <i class="fas fa-star star-icon"></i>
-        Celestial Chat
-    </h1>
-    <div class="header-actions">
-        <button class="settings-btn" onclick="toggleSettings()">
-            <i class="fas fa-cog"></i> Configuración
-        </button>
-    </div>
-</header>
-
-<!-- Settings Panel -->
-<div id="settings-panel" class="settings-panel">
-    <form method="post">
-        <div class="settings-row">
-            <label><i class="fas fa-palette"></i> Tema:</label>
-            <select name="tema">
-                <option value="dark" <?php if($pref['tema']==='dark') echo 'selected'; ?>>🌙 Oscuro</option>
-                <option value="light" <?php if($pref['tema']==='light') echo 'selected'; ?>>☀️ Claro</option>
-            </select>
-        </div>
-        <div class="settings-row">
-            <label><i class="fas fa-paint-brush"></i> Color:</label>
-            <input type="color" name="color" value="<?php echo htmlspecialchars($pref['color_preferido']); ?>">
-            <button type="submit" class="settings-btn">
-                <i class="fas fa-save"></i> Guardar
-            </button>
-        </div>
-    </form>
-</div>
-
-<!-- Chat Container -->
+<body>
 <div class="chat-container">
     <div class="chat-window" id="chat-window">
         <?php if (empty($mensajes)): ?>
             <div class="empty-state">
                 <i class="fas fa-comments"></i>
-                <h3>¡Bienvenido al Chat Celestial!</h3>
+                <h3>¡Bienvenido!</h3>
                 <p>Comienza una conversación escribiendo tu primer mensaje.</p>
             </div>
         <?php else: ?>
@@ -228,14 +129,13 @@ $mensajes = $stmt->fetchAll();
             <?php endforeach; ?>
         <?php endif; ?>
     </div>
-    
-    <!-- Input Area -->
+
     <div class="input-area">
         <form method="post" class="input-form">
-            <input 
-                name="mensaje" 
+            <input
+                name="mensaje"
                 class="message-input"
-                placeholder="✨ Escribe tu mensaje mágico aquí..." 
+                placeholder="Escribe tu mensaje..."
                 type="text"
                 autocomplete="off"
                 required
@@ -245,10 +145,15 @@ $mensajes = $stmt->fetchAll();
                 <span>Enviar</span>
             </button>
         </form>
+        <form method="post" class="finalizar-form">
+            <button type="submit" name="finalizar" class="finalize-btn">Finalizar y generar informe</button>
+        </form>
+        <div class="mode-choice">
+            <a href="questionnaire.php">Responder preguntas directamente</a>
+        </div>
     </div>
 </div>
 
-<!-- Navigation -->
 <nav class="navigation">
     <a href="profile.php" class="nav-link">
         <i class="fas fa-user-circle"></i>
@@ -261,20 +166,11 @@ $mensajes = $stmt->fetchAll();
 </nav>
 
 <script>
-// Toggle Settings Panel
-function toggleSettings() {
-    const panel = document.getElementById('settings-panel');
-    panel.style.display = panel.style.display === 'none' || panel.style.display === '' ? 'block' : 'none';
-}
-
-// Delete Message
 function deleteMessage(id) {
     if (confirm('¿Estás seguro de que quieres eliminar este mensaje?')) {
         window.location.href = '?del_msg=' + id;
     }
 }
-
-// Auto-scroll to bottom
 function scrollToBottom() {
     const chatWindow = document.getElementById('chat-window');
     chatWindow.scrollTop = chatWindow.scrollHeight;
@@ -292,26 +188,9 @@ document.querySelector('.message-input').addEventListener('keypress', function(e
         this.closest('form').submit();
     }
 });
-
-document.addEventListener('click', function(e) {
-    const panel = document.getElementById('settings-panel');
-    const settingsBtn = document.querySelector('.settings-btn');
-    
-    if (!panel.contains(e.target) && !settingsBtn.contains(e.target)) {
-        panel.style.display = 'none';
-    }
-});
-
-let typingDots = 0;
-setInterval(() => {
-    const input = document.querySelector('.message-input');
-    if (document.activeElement === input && input.value === '') {
-        typingDots = (typingDots + 1) % 4;
-        const dots = '.'.repeat(typingDots);
-        input.placeholder = `✨ Escribe tu mensaje mágico aquí${dots}`;
-    }
-}, 500);
 </script>
+
+<?php include 'branch.php'; ?>
 
 </body>
 </html>

--- a/chat_helpers.php
+++ b/chat_helpers.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Utility helpers for chat conversation.
+ */
+function build_base_messages(PDO $pdo, int $usuario_id): array {
+    $messages = [];
+
+    // Load prompt set associated with the user
+    $setStmt = $pdo->prepare('SELECT prompt_set_id FROM usuarios WHERE id = ?');
+    $setStmt->execute([$usuario_id]);
+    $setId = $setStmt->fetchColumn();
+    if ($setId) {
+        $pstmt = $pdo->prepare('SELECT role, content FROM prompt_lines WHERE set_id = ? ORDER BY orden');
+        $pstmt->execute([$setId]);
+        foreach ($pstmt->fetchAll() as $p) {
+            $messages[] = ['role' => $p['role'], 'content' => $p['content']];
+        }
+    }
+
+    // Gather admin-defined questions to guide the conversation
+    $qstmt = $pdo->query('SELECT texto_pregunta FROM preguntas_admin ORDER BY orden');
+    $questions = $qstmt->fetchAll(PDO::FETCH_COLUMN);
+    if ($questions) {
+        $messages[] = [
+            'role' => 'system',
+            'content' => 'Recopila la siguiente información integrándola de manera natural en la conversación: ' . implode(' | ', $questions) . '. Cuando ya no puedas obtener más datos relevantes, resume todo y ofrece la posibilidad de confirmar o ajustar el resumen.'
+        ];
+    }
+
+    return $messages;
+}
+?>

--- a/forgot-password.php
+++ b/forgot-password.php
@@ -82,5 +82,6 @@ $token = $_GET['token'] ?? null;
         </div>
     </div>
 </div>
+<?php include 'branch.php'; ?>
 </body>
 </html>

--- a/login.php
+++ b/login.php
@@ -207,5 +207,7 @@ function animateCard() {
 animateCard();
 </script>
 
+<?php include 'branch.php'; ?>
+
 </body>
 </html>

--- a/logout.php
+++ b/logout.php
@@ -479,5 +479,7 @@ function animateCard() {
 animateCard();
 </script>
 
+<?php include 'branch.php'; ?>
+
 </body>
 </html>

--- a/privacy.php
+++ b/privacy.php
@@ -12,5 +12,6 @@
 <p>Este chat almacena los mensajes enviados por los usuarios y las respuestas generadas con la API de OpenAI.
 Los datos de perfil se guardan para mantener el historial y personalizar la experiencia.
 Puedes actualizar o eliminar tu información en cualquier momento desde tu <a href="profile.php">perfil</a>.</p>
+<?php include 'branch.php'; ?>
 </body>
 </html>

--- a/profile.php
+++ b/profile.php
@@ -352,5 +352,7 @@ document.addEventListener('keydown', function(e) {
 });
 </script>
 
+<?php include 'branch.php'; ?>
+
 </body>
 </html>

--- a/prompts.php
+++ b/prompts.php
@@ -5,19 +5,11 @@ $promptSets = [
     'default' => [
         [
             'role' => 'system',
-            'content' => 'Eres un asistente que realiza una encuesta de forma amena para comprender el negocio del usuario. Informa que las respuestas se guardan y que se utiliza la API de OpenAI.'
+            'content' => 'Eres un asistente de investigación de marca. Conversa de forma amigable para recopilar información que ayude a definir la identidad de una marca y el diseño de su logotipo. Mantente enfocado en esta misión y deriva cordialmente cualquier tema ajeno al objetivo.'
         ],
         [
             'role' => 'assistant',
-            'content' => '¡Hola! Antes de empezar, puedes indicarme tu nombre o cómo prefieres que te llame?'
-        ],
-        [
-            'role' => 'assistant',
-            'content' => '¿Cuál es el objetivo principal de tu negocio o proyecto?'
-        ],
-        [
-            'role' => 'assistant',
-            'content' => '¿Tienes alguna preferencia de estilo o colores para la imagen de tu marca?'
+            'content' => 'Hola, estoy aquí para ayudarte a definir tu marca. Si lo prefieres, puedes responder un formulario directamente en lugar de conversar. ¿Qué opción eliges?'
         ],
     ],
 ];
@@ -27,3 +19,4 @@ if (php_sapi_name() === 'cli' && basename(__FILE__) === basename($_SERVER['SCRIP
 }
 
 return $promptSets;
+?>

--- a/questionnaire.php
+++ b/questionnaire.php
@@ -1,0 +1,61 @@
+<?php
+session_start();
+require 'db.php';
+require 'openai.php';
+require 'chat_helpers.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$usuario_id = $_SESSION['usuario_id'];
+
+$qstmt = $pdo->query('SELECT id, texto_pregunta FROM preguntas_admin ORDER BY orden');
+$preguntas = $qstmt->fetchAll();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    foreach ($preguntas as $preg) {
+        $answer = trim($_POST['pregunta_' . $preg['id']] ?? '');
+        if ($answer !== '') {
+            $ins = $pdo->prepare('REPLACE INTO respuestas (usuario_id, pregunta_id, respuesta) VALUES (?, ?, ?)');
+            $ins->execute([$usuario_id, $preg['id'], $answer]);
+        }
+    }
+
+    $resStmt = $pdo->prepare('SELECT p.texto_pregunta, r.respuesta FROM respuestas r JOIN preguntas_admin p ON r.pregunta_id = p.id WHERE r.usuario_id = ? ORDER BY p.orden');
+    $resStmt->execute([$usuario_id]);
+    $pairs = $resStmt->fetchAll();
+    $text = "";
+    foreach ($pairs as $pr) {
+        $text .= $pr['texto_pregunta'] . ": " . $pr['respuesta'] . "\n";
+    }
+    $messages = build_base_messages($pdo, $usuario_id);
+    $messages[] = ['role' => 'user', 'content' => "Respuestas del formulario:\n" . $text];
+    $messages[] = ['role' => 'system', 'content' => 'Genera un informe estructurado con la información proporcionada.'];
+    $analysis = call_openai_api($messages);
+    $stmt = $pdo->prepare("INSERT INTO resultados_analisis (usuario_id, analisis) VALUES (?, ?) ON DUPLICATE KEY UPDATE analisis = VALUES(analisis), fecha_registro = CURRENT_TIMESTAMP");
+    $stmt->execute([$usuario_id, $analysis]);
+    header('Location: summary.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Formulario de preguntas</title>
+</head>
+<body>
+<h1>Responder preguntas</h1>
+<form method="post">
+<?php foreach ($preguntas as $p): ?>
+    <label><?php echo htmlspecialchars($p['texto_pregunta']); ?></label><br>
+    <textarea name="pregunta_<?php echo $p['id']; ?>" rows="2" cols="50"></textarea><br><br>
+<?php endforeach; ?>
+    <button type="submit">Enviar</button>
+</form>
+<p><a href="chat.php">Volver al chat</a></p>
+<?php include 'branch.php'; ?>
+</body>
+</html>

--- a/register.php
+++ b/register.php
@@ -42,5 +42,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </form>
 <p style="font-size:small">Al registrarte aceptas la <a href="privacy.php">política de privacidad</a> y que tus datos sean almacenados.</p>
 <?php if (!empty($error)) echo "<p>$error</p>"; ?>
+<?php include 'branch.php'; ?>
 </body>
 </html>

--- a/schema.sql
+++ b/schema.sql
@@ -32,27 +32,9 @@ CREATE TABLE IF NOT EXISTS usuarios (
     password     VARCHAR(255) NOT NULL,
     foto         VARCHAR(255),
     es_admin     TINYINT(1) DEFAULT 0,
-<<<<<<< HEAD
-    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-=======
     prompt_set_id INT DEFAULT NULL,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id)
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Design preferences
-CREATE TABLE IF NOT EXISTS preferencias_disenio (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    usuario_id INT NOT NULL,
-    tema ENUM('light','dark') DEFAULT 'light',
-    color_preferido VARCHAR(50),
-    FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Conversations
@@ -62,10 +44,6 @@ CREATE TABLE IF NOT EXISTS conversaciones (
     fecha_inicio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Messages
@@ -76,10 +54,6 @@ CREATE TABLE IF NOT EXISTS mensajes (
     texto TEXT NOT NULL,
     fecha_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (conversacion_id) REFERENCES conversaciones(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Admin defined questions
@@ -87,10 +61,6 @@ CREATE TABLE IF NOT EXISTS preguntas_admin (
     id INT AUTO_INCREMENT PRIMARY KEY,
     texto_pregunta TEXT NOT NULL,
     orden INT DEFAULT 0
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- User answers to admin questions
@@ -102,10 +72,6 @@ CREATE TABLE IF NOT EXISTS respuestas (
     fecha_respuesta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
     FOREIGN KEY (pregunta_id) REFERENCES preguntas_admin(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Optional analysis results
@@ -115,26 +81,6 @@ CREATE TABLE IF NOT EXISTS resultados_analisis (
     analisis TEXT,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Prompt sets to allow different base instructions
-CREATE TABLE IF NOT EXISTS prompt_sets (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    nombre VARCHAR(100) NOT NULL
-);
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Messages belonging to each prompt set
-CREATE TABLE IF NOT EXISTS prompt_lines (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    set_id INT NOT NULL,
-    role ENUM('system','assistant','user') NOT NULL,
-    content TEXT NOT NULL,
-    orden INT DEFAULT 0,
-    FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE
-);
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Password reset tokens for recovery process
@@ -143,14 +89,4 @@ CREATE TABLE IF NOT EXISTS password_resets (
     token VARCHAR(64) NOT NULL,
     expires_at DATETIME NOT NULL,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-);
-
-ALTER TABLE usuarios
-    ADD COLUMN IF NOT EXISTS prompt_set_id INT DEFAULT NULL,
-    ADD COLUMN prompt_set_id INT DEFAULT NULL,
-    ADD CONSTRAINT fk_prompt_set
-        FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id);
-=======
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query

--- a/summary.php
+++ b/summary.php
@@ -1,0 +1,40 @@
+<?php
+session_start();
+require 'db.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$usuario_id = $_SESSION['usuario_id'];
+
+$stmt = $pdo->prepare('SELECT analisis FROM resultados_analisis WHERE usuario_id = ? ORDER BY fecha_registro DESC LIMIT 1');
+$stmt->execute([$usuario_id]);
+$analysis = $stmt->fetchColumn();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    header('Location: chat.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Resumen</title>
+</head>
+<body>
+<h1>Resumen de la información</h1>
+<?php if ($analysis): ?>
+<p><?php echo nl2br(htmlspecialchars($analysis)); ?></p>
+<?php else: ?>
+<p>No hay información registrada.</p>
+<?php endif; ?>
+<form method="post">
+    <button type="submit">Confirmar</button>
+</form>
+<p><a href="chat.php">Solicitar ajustes</a></p>
+<?php include 'branch.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Simplify chat by removing theme preferences and wiring conversation through reusable helpers
- Load admin questions as system guidance and provide direct questionnaire option
- Generate and store final analysis summary for review
- Display current Git branch on all frontend pages

## Testing
- `php -l branch.php admin.php chat.php login.php register.php profile.php questionnaire.php summary.php forgot-password.php privacy.php logout.php`


------
https://chatgpt.com/codex/tasks/task_e_688d63197cd483258030d972623edf5e