### PR TITLE
Quote role column in prompt lines queries

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -45,11 +45,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     if (isset($_POST['add_line'])) {
-        $stmt = $pdo->prepare('INSERT INTO prompt_lines (set_id, role, content, orden) VALUES (?,?,?,?)');
+        $stmt = $pdo->prepare('INSERT INTO prompt_lines (set_id, `role`, content, orden) VALUES (?,?,?,?)');
         $stmt->execute([$selectedSet, $_POST['line_role'], $_POST['line_content'], (int)$_POST['line_order']]);
     }
     if (isset($_POST['edit_line'])) {
-        $stmt = $pdo->prepare('UPDATE prompt_lines SET role = ?, content = ?, orden = ? WHERE id = ?');
+        $stmt = $pdo->prepare('UPDATE prompt_lines SET `role` = ?, content = ?, orden = ? WHERE id = ?');
         $stmt->execute([$_POST['line_role'], $_POST['line_content'], (int)$_POST['line_order'], $_POST['line_id']]);
     }
 }
@@ -72,7 +72,7 @@ $promptSets = $pdo->query('SELECT id, nombre FROM prompt_sets ORDER BY id')->fet
 $questions = $pdo->query('SELECT id, texto_pregunta FROM preguntas_admin ORDER BY id')->fetchAll();
 $promptLines = [];
 if ($selectedSet) {
-    $stmt = $pdo->prepare('SELECT id, role, content, orden FROM prompt_lines WHERE set_id = ? ORDER BY orden');
+    $stmt = $pdo->prepare('SELECT id, `role`, content, orden FROM prompt_lines WHERE set_id = ? ORDER BY orden');
     $stmt->execute([$selectedSet]);
     $promptLines = $stmt->fetchAll();
 }

--- a/chat.php
+++ b/chat.php
@@ -124,7 +124,7 @@ if (isset($_POST['mensaje']) && trim($_POST['mensaje']) !== '') {
         $setStmt->execute([$usuario_id]);
         $setId = $setStmt->fetchColumn();
         if ($setId) {
-            $pstmt = $pdo->prepare('SELECT role, content FROM prompt_lines WHERE set_id = ? ORDER BY orden');
+            $pstmt = $pdo->prepare('SELECT `role`, content FROM prompt_lines WHERE set_id = ? ORDER BY orden');
             $pstmt->execute([$setId]);
             $basePrompts = [];
             foreach ($pstmt->fetchAll() as $p) {

--- a/init_prompts.php
+++ b/init_prompts.php
@@ -11,7 +11,7 @@ if ($exists > 0) {
 $promptSets = include 'prompts.php';
 
 $insertSet = $pdo->prepare('INSERT INTO prompt_sets (nombre) VALUES (?)');
-$insertLine = $pdo->prepare('INSERT INTO prompt_lines (set_id, role, content, orden) VALUES (?, ?, ?, ?)');
+$insertLine = $pdo->prepare('INSERT INTO prompt_lines (set_id, `role`, content, orden) VALUES (?, ?, ?, ?)');
 
 $totalLines = 0;
 foreach ($promptSets as $name => $messages) {

--- a/schema.sql
+++ b/schema.sql
@@ -32,14 +32,9 @@ CREATE TABLE IF NOT EXISTS usuarios (
     password     VARCHAR(255) NOT NULL,
     foto         VARCHAR(255),
     es_admin     TINYINT(1) DEFAULT 0,
-<<<<<<< HEAD
-    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-=======
     prompt_set_id INT DEFAULT NULL,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id)
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Design preferences
@@ -49,10 +44,6 @@ CREATE TABLE IF NOT EXISTS preferencias_disenio (
     tema ENUM('light','dark') DEFAULT 'light',
     color_preferido VARCHAR(50),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Conversations
@@ -62,10 +53,6 @@ CREATE TABLE IF NOT EXISTS conversaciones (
     fecha_inicio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Messages
@@ -76,10 +63,6 @@ CREATE TABLE IF NOT EXISTS mensajes (
     texto TEXT NOT NULL,
     fecha_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (conversacion_id) REFERENCES conversaciones(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Admin defined questions
@@ -87,10 +70,6 @@ CREATE TABLE IF NOT EXISTS preguntas_admin (
     id INT AUTO_INCREMENT PRIMARY KEY,
     texto_pregunta TEXT NOT NULL,
     orden INT DEFAULT 0
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- User answers to admin questions
@@ -102,10 +81,6 @@ CREATE TABLE IF NOT EXISTS respuestas (
     fecha_respuesta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
     FOREIGN KEY (pregunta_id) REFERENCES preguntas_admin(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Optional analysis results
@@ -115,26 +90,6 @@ CREATE TABLE IF NOT EXISTS resultados_analisis (
     analisis TEXT,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Prompt sets to allow different base instructions
-CREATE TABLE IF NOT EXISTS prompt_sets (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    nombre VARCHAR(100) NOT NULL
-);
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Messages belonging to each prompt set
-CREATE TABLE IF NOT EXISTS prompt_lines (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    set_id INT NOT NULL,
-    `role` ENUM('system','assistant','user') NOT NULL,
-    content TEXT NOT NULL,
-    orden INT DEFAULT 0,
-    FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE
-);
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Password reset tokens for recovery process
@@ -143,14 +98,4 @@ CREATE TABLE IF NOT EXISTS password_resets (
     token VARCHAR(64) NOT NULL,
     expires_at DATETIME NOT NULL,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-);
-
-ALTER TABLE usuarios
-    ADD COLUMN IF NOT EXISTS prompt_set_id INT DEFAULT NULL,
-    ADD COLUMN prompt_set_id INT DEFAULT NULL,
-    ADD CONSTRAINT fk_prompt_set
-        FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id);
-=======
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query

--- a/schema.sql
+++ b/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS prompt_sets (
 CREATE TABLE IF NOT EXISTS prompt_lines (
     id INT AUTO_INCREMENT PRIMARY KEY,
     set_id INT NOT NULL,
-    role ENUM('system','assistant','user') NOT NULL,
+    `role` ENUM('system','assistant','user') NOT NULL,
     content TEXT NOT NULL,
     orden INT DEFAULT 0,
     FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE
@@ -130,7 +130,7 @@ CREATE TABLE IF NOT EXISTS prompt_sets (
 CREATE TABLE IF NOT EXISTS prompt_lines (
     id INT AUTO_INCREMENT PRIMARY KEY,
     set_id INT NOT NULL,
-    role ENUM('system','assistant','user') NOT NULL,
+    `role` ENUM('system','assistant','user') NOT NULL,
     content TEXT NOT NULL,
     orden INT DEFAULT 0,
     FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE


### PR DESCRIPTION
## Summary
- escape `role` column in SQL queries for prompt lines
- ensure seeding scripts and chat retrieval handle reserved keyword
- quote `role` column in schema to support future migrations

## Testing
- `php -l admin.php`
- `php -l init_prompts.php`
- `php -l chat.php`


------
https://chatgpt.com/codex/tasks/task_e_688d873958bc83258b7e1b7a5dfa46c5