### PR TITLE
feat: add prompt loading with context

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+class User
+{
+    public function __construct(
+        public int $id,
+        public string $name = ''
+    ) {
+    }
+}
+

--- a/app/Repositories/ConversationRepository.php
+++ b/app/Repositories/ConversationRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+interface ConversationRepository
+{
+    public function recent(int $userId, int $tokenBudget): array;
+}
+

--- a/app/Repositories/PromptRepository.php
+++ b/app/Repositories/PromptRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+interface PromptRepository
+{
+    public function findBySlug(string $slug): object;
+}
+

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+interface UserRepository
+{
+    public function getProfile(int $userId): array;
+}
+

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\User;
+
+class ChatService
+{
+    public function __construct(
+        private PromptLoader $promptLoader,
+        private TokenCounter $tokenCounter
+    ) {
+    }
+
+    public function buildMessages(User $user, string $currentMessage): array
+    {
+        $messages = $this->promptLoader->buildMerlinPrompt($user);
+        $messages[] = ['role' => 'user', 'content' => $currentMessage];
+
+        $tokenCount = $this->tokenCounter->count($messages);
+        if ($tokenCount > 7000) {
+            $budget = 1800;
+            do {
+                $budget -= 200;
+                $messages = $this->promptLoader->buildMerlinPrompt($user, $budget);
+                $messages[] = ['role' => 'user', 'content' => $currentMessage];
+                $tokenCount = $this->tokenCounter->count($messages);
+            } while ($tokenCount > 7000 && $budget > 0);
+        }
+
+        return $messages;
+    }
+}
+

--- a/app/Services/ContextBuilder.php
+++ b/app/Services/ContextBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Repositories\ConversationRepository;
+use App\Repositories\UserRepository;
+
+class ContextBuilder
+{
+    public function __construct(
+        private UserRepository $users,
+        private ConversationRepository $convos
+    ) {
+    }
+
+    public function build(int $userId, int $tokenBudget = 1800): array
+    {
+        $profile = $this->users->getProfile($userId);
+        $recent = $this->convos->recent($userId, $tokenBudget);
+
+        return [
+            'profile' => $profile,
+            'recent_conversation' => $recent,
+        ];
+    }
+}
+

--- a/app/Services/PromptLoader.php
+++ b/app/Services/PromptLoader.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\User;
+use App\Repositories\ConversationRepository;
+use App\Repositories\PromptRepository;
+use App\Repositories\UserRepository;
+
+class PromptLoader
+{
+    public function __construct(
+        private PromptRepository $promptRepo,
+        private UserRepository $users,
+        private ConversationRepository $convos
+    ) {
+    }
+
+    public function buildMerlinPrompt(User $user, int $tokenBudget = 1800): array
+    {
+        $master = $this->promptRepo->findBySlug('merlin_master')->content;
+
+        $context = (new ContextBuilder($this->users, $this->convos))
+            ->build($user->id, $tokenBudget);
+
+        return [
+            ['role' => 'system', 'content' => $master],
+            [
+                'role' => 'system',
+                'content' => 'CONTEXTO_USUARIO\n' .
+                    json_encode($context, JSON_UNESCAPED_UNICODE),
+            ],
+        ];
+    }
+}
+

--- a/app/Services/TokenCounter.php
+++ b/app/Services/TokenCounter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+class TokenCounter
+{
+    /**
+     * Very naive token counter based on word count.
+     */
+    public function count(array $messages): int
+    {
+        $tokens = 0;
+        foreach ($messages as $message) {
+            if (! isset($message['content'])) {
+                continue;
+            }
+            $tokens += str_word_count((string) $message['content']);
+        }
+        return $tokens;
+    }
+}
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "merlin/playground",
+    "type": "project",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^10.5",
+        "squizlabs/php_codesniffer": "^3.9"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+        "fix": "vendor/bin/phpcbf --standard=PSR12 app tests"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Feature/PromptLoaderTest.php
+++ b/tests/Feature/PromptLoaderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Repositories\ConversationRepository;
+use App\Repositories\PromptRepository;
+use App\Repositories\UserRepository;
+use App\Services\PromptLoader;
+use App\Services\TokenCounter;
+use PHPUnit\Framework\TestCase;
+
+class PromptLoaderTest extends TestCase
+{
+    public function test_includes_master_prompt_and_context(): void
+    {
+        $userRepo = new class implements UserRepository {
+            public function getProfile(int $userId): array
+            {
+                return ['name' => 'Alice'];
+            }
+        };
+
+        $conversationRepo = new class implements ConversationRepository {
+            public function recent(int $userId, int $tokenBudget): array
+            {
+                return [
+                    ['role' => 'user', 'content' => 'hola'],
+                ];
+            }
+        };
+
+        $promptRepo = new class implements PromptRepository {
+            public function findBySlug(string $slug): object
+            {
+                return (object) ['content' => 'PROMPT_MASTER'];
+            }
+        };
+
+        $loader = new PromptLoader($promptRepo, $userRepo, $conversationRepo);
+        $messages = $loader->buildMerlinPrompt(new User(1));
+
+        $this->assertSame('PROMPT_MASTER', $messages[0]['content']);
+
+        $contextJson = substr($messages[1]['content'], strlen('CONTEXTO_USUARIO\n'));
+        $context = json_decode($contextJson, true);
+        $this->assertSame('Alice', $context['profile']['name']);
+        $this->assertSame('hola', $context['recent_conversation'][0]['content']);
+    }
+
+    public function test_truncates_recent_conversation_to_token_budget(): void
+    {
+        $allMessages = [];
+        for ($i = 1; $i <= 2000; $i++) {
+            $allMessages[] = ['role' => 'user', 'content' => 'msg' . $i];
+        }
+
+        $conversationRepo = new class($allMessages) implements ConversationRepository {
+            public function __construct(private array $messages)
+            {
+            }
+
+            public function recent(int $userId, int $tokenBudget): array
+            {
+                $counter = new TokenCounter();
+                $result = [];
+                $tokens = 0;
+                for ($i = count($this->messages) - 1; $i >= 0; $i--) {
+                    $msg = $this->messages[$i];
+                    $msgTokens = $counter->count([$msg]);
+                    if ($tokens + $msgTokens > $tokenBudget) {
+                        break;
+                    }
+                    array_unshift($result, $msg);
+                    $tokens += $msgTokens;
+                }
+                return $result;
+            }
+        };
+
+        $userRepo = new class implements UserRepository {
+            public function getProfile(int $userId): array
+            {
+                return ['name' => 'Bob'];
+            }
+        };
+
+        $promptRepo = new class implements PromptRepository {
+            public function findBySlug(string $slug): object
+            {
+                return (object) ['content' => 'PROMPT'];
+            }
+        };
+
+        $loader = new PromptLoader($promptRepo, $userRepo, $conversationRepo);
+        $messages = $loader->buildMerlinPrompt(new User(1));
+        $contextJson = substr($messages[1]['content'], strlen('CONTEXTO_USUARIO\n'));
+        $context = json_decode($contextJson, true);
+        $recent = $context['recent_conversation'];
+
+        $counter = new TokenCounter();
+        $tokenCount = $counter->count($recent);
+        $this->assertLessThanOrEqual(1800, $tokenCount);
+        $this->assertSame('msg201', $recent[0]['content']);
+        $this->assertSame('msg2000', $recent[count($recent) - 1]['content']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add PromptLoader to prepend master prompt and user context
- build ContextBuilder and ChatService for message assembly
- introduce tests ensuring prompt and context composition

## Testing
- `composer fix` *(fails: vendor/bin/phpcbf: not found)*
- `composer test` *(fails: vendor/bin/phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d8e26600083258fb34ab9208bd9e0