### PR TITLE
Resolve merge conflicts in MySQL schema

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -32,14 +32,9 @@ CREATE TABLE IF NOT EXISTS usuarios (
     password     VARCHAR(255) NOT NULL,
     foto         VARCHAR(255),
     es_admin     TINYINT(1) DEFAULT 0,
-<<<<<<< HEAD
-    fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-=======
     prompt_set_id INT DEFAULT NULL,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id)
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Design preferences
@@ -49,10 +44,6 @@ CREATE TABLE IF NOT EXISTS preferencias_disenio (
     tema ENUM('light','dark') DEFAULT 'light',
     color_preferido VARCHAR(50),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Conversations
@@ -62,10 +53,6 @@ CREATE TABLE IF NOT EXISTS conversaciones (
     fecha_inicio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Messages
@@ -76,10 +63,6 @@ CREATE TABLE IF NOT EXISTS mensajes (
     texto TEXT NOT NULL,
     fecha_envio TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (conversacion_id) REFERENCES conversaciones(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Admin defined questions
@@ -87,10 +70,6 @@ CREATE TABLE IF NOT EXISTS preguntas_admin (
     id INT AUTO_INCREMENT PRIMARY KEY,
     texto_pregunta TEXT NOT NULL,
     orden INT DEFAULT 0
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- User answers to admin questions
@@ -102,10 +81,6 @@ CREATE TABLE IF NOT EXISTS respuestas (
     fecha_respuesta TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
     FOREIGN KEY (pregunta_id) REFERENCES preguntas_admin(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-=======
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Optional analysis results
@@ -115,26 +90,6 @@ CREATE TABLE IF NOT EXISTS resultados_analisis (
     analisis TEXT,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-<<<<<<< HEAD
-);
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Prompt sets to allow different base instructions
-CREATE TABLE IF NOT EXISTS prompt_sets (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    nombre VARCHAR(100) NOT NULL
-);
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
--- Messages belonging to each prompt set
-CREATE TABLE IF NOT EXISTS prompt_lines (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    set_id INT NOT NULL,
-    role ENUM('system','assistant','user') NOT NULL,
-    content TEXT NOT NULL,
-    orden INT DEFAULT 0,
-    FOREIGN KEY (set_id) REFERENCES prompt_sets(id) ON DELETE CASCADE
-);
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Password reset tokens for recovery process
@@ -143,14 +98,5 @@ CREATE TABLE IF NOT EXISTS password_resets (
     token VARCHAR(64) NOT NULL,
     expires_at DATETIME NOT NULL,
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
-);
-
-ALTER TABLE usuarios
-    ADD COLUMN IF NOT EXISTS prompt_set_id INT DEFAULT NULL,
-    ADD COLUMN prompt_set_id INT DEFAULT NULL,
-    ADD CONSTRAINT fk_prompt_set
-        FOREIGN KEY (prompt_set_id) REFERENCES prompt_sets(id);
-=======
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
->>>>>>> origin/codex/fix-syntax-error-in-mysql-query


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers in `schema.sql`
- add `prompt_set_id` column and foreign key to `usuarios`
- restore `password_resets` table and ensure all CREATE TABLE statements close properly

## Testing
- `mysql --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `pip install sqlfluff` *(fails: proxy 403)*
- `sqlite3 :memory: < schema.sql` *(fails: MySQL syntax not compatible)*

------
https://chatgpt.com/codex/tasks/task_e_688da50f6688832595afe177356db5e1